### PR TITLE
fix: Tolerate Redis being down

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,11 @@ class FakeCacheConfigProvider:
         )
 
 
+@pytest.fixture
+def redis_port() -> int:
+    return REDIS_PORT
+
+
 @pytest.fixture(scope="session")
 def redis_server() -> Generator[redislite.Redis, None, None]:
     # Create a redislite instance listening on TCP port 6397. Default is 6379, so we avoid that to prevent conflicts.


### PR DESCRIPTION
If redis is not available, `RedisCache` will just disable itself.  

This is useful for using GCache in no Redis env.