### PR TITLE
feat: optional RedisConfig

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,11 +24,6 @@ class FakeCacheConfigProvider:
         )
 
 
-@pytest.fixture
-def redis_port() -> int:
-    return REDIS_PORT
-
-
 @pytest.fixture(scope="session")
 def redis_server() -> Generator[redislite.Redis, None, None]:
     # Create a redislite instance listening on TCP port 6397. Default is 6379, so we avoid that to prevent conflicts.

--- a/tests/test_gcache.py
+++ b/tests/test_gcache.py
@@ -24,6 +24,8 @@ from cachegalileo.base import (
 )
 from tests.conftest import FakeCacheConfigProvider
 
+from .conftest import REDIS_PORT
+
 
 def test_gcache_sync(gcache: GCache) -> None:
     v: int = 0
@@ -388,16 +390,15 @@ def test_gcache_serialize() -> None:
     assert key == key3
 
 
-def test_redis_disabled(
-    cache_config_provider: FakeCacheConfigProvider, redis_port: int, redis_server: redislite.Redis
+@pytest.mark.parametrize("redis_config", [RedisConfig(port=REDIS_PORT - 1), None])
+def test_redis_down(
+    cache_config_provider: FakeCacheConfigProvider, redis_server: redislite.Redis, redis_config: RedisConfig | None
 ) -> None:
     redis_server.flushall()
 
     gcache = GCache(
         GCacheConfig(
-            cache_config_provider=cache_config_provider,
-            urn_prefix="urn:galileo:test",
-            redis_config=RedisConfig(port=redis_port - 1),
+            cache_config_provider=cache_config_provider, urn_prefix="urn:galileo:test", redis_config=redis_config
         )
     )
     try:


### PR DESCRIPTION
Now user can provide None for RedisConfig when making GCache.  In that case Redis won't be used at all.