### PR TITLE
fix: pretty print configs when serializing

### DIFF
--- a/src/cachegalileo/base.py
+++ b/src/cachegalileo/base.py
@@ -105,9 +105,9 @@ class GCacheKeyConfig(BaseModel):
         data_dict: dict[str, Any] = {}
         for k, v in data.items():
             if isinstance(v, GCacheKeyConfig):
-                data_dict[k] = v.dumps()
+                data_dict[k] = v.dict()
             else:
-                data_dict[k] = {k: v.dumps() for k, v in v.items()}
+                data_dict[k] = {k: v.dict() for k, v in v.items()}
 
         return json.dumps(data_dict, indent=2)
 

--- a/tests/test_gcache.py
+++ b/tests/test_gcache.py
@@ -555,6 +555,22 @@ def test_config_serialization_deserialization() -> None:
         },
     }
 
+    # In previous release the gcache key configs were encoded as a string instead of dict, so we can test if
+    # new approach will parse older format correctly.
+    old_config_json = """
+{
+    "old_schema_use_case": "{\\"ttl_sec\\": {\\"local\\": 10, \\"remote\\": 1}, \\"ramp\\": {\\"local\\": 0, \\"remote\\": 0}}",
+    "defaults": {
+        "test": "{\\"ttl_sec\\": {\\"local\\": 5, \\"remote\\": 6}, \\"ramp\\": {\\"local\\": 100, \\"remote\\": 100}}"
+    },
+    "customer_foo": {
+        "test": "{\\"ttl_sec\\": {\\"local\\": 7, \\"remote\\": 8}, \\"ramp\\": {\\"local\\": 0, \\"remote\\": 0}}"
+    }
+}
+    """
+
     json_str = GCacheKeyConfig.dump_configs(configs)  # type: ignore[arg-type]
     configs_deserialized = GCacheKeyConfig.load_configs(json_str)
     assert configs == configs_deserialized
+
+    assert GCacheKeyConfig.load_configs(old_config_json) == configs


### PR DESCRIPTION
Previous iteration was serializing keys as quote escaped json, which doesn't pretty print properly when serialized.

With this change, the output JSON will be all entirely JSON, including key representation.  

I also test that previous format will still be parsed correctly.