### PR TITLE
fix: preserve function name after its decorated

### DIFF
--- a/src/cachegalileo/base.py
+++ b/src/cachegalileo/base.py
@@ -1,6 +1,7 @@
 import asyncio
 import builtins
 import contextvars
+import functools
 import inspect
 import json
 import pickle
@@ -904,7 +905,7 @@ class GCache:
                 return await self._cache.get(key, f)
 
             if inspect.iscoroutinefunction(func):
-                return async_wrapped
+                return functools.wraps(func)(async_wrapped)
             else:
 
                 def sync_wrapped(*args: Any, **kwargs: Any) -> Any:
@@ -916,7 +917,7 @@ class GCache:
 
                     return self._run_coroutine_in_thread(partial(async_wrapped, *args, **kwargs))
 
-                return sync_wrapped
+                return functools.wraps(func)(sync_wrapped)
 
         return decorator
 

--- a/tests/test_gcache.py
+++ b/tests/test_gcache.py
@@ -574,3 +574,21 @@ def test_config_serialization_deserialization() -> None:
     assert configs == configs_deserialized
 
     assert GCacheKeyConfig.load_configs(old_config_json) == configs
+
+
+def test_preserve_func_metadata(gcache: GCache) -> None:
+    class FooBar:
+        @gcache.cached(key_type="Test", id_arg="test")
+        def some_method(self, test: int = 123) -> int:
+            return 123
+
+    assert FooBar.some_method.__name__ == "some_method"
+
+
+def test_preserve_func_metadata_async(gcache: GCache) -> None:
+    class FooBar:
+        @gcache.cached(key_type="Test", id_arg="test")
+        async def some_method(self, test: int = 123) -> int:
+            return 123
+
+    assert FooBar.some_method.__name__ == "some_method"


### PR DESCRIPTION
Preserve function name after its being decorated.

This is important for instrumentation.