### PR TITLE
fix: forbid reentrant sync cached funcs

### DIFF
--- a/src/gcache/event_loop_thread.py
+++ b/src/gcache/event_loop_thread.py
@@ -88,7 +88,6 @@ class EventLoopThreadPool(EventLoopThreadInterface):
                     for thread in self.threads:
                         thread.start()
                     logger.info(f"Initialized EventLoopThreadPool {self.name}")
-
         return random.choice(self.threads).submit(async_fn, wait_for_result)
 
     def stop(self, timeout_sec: int = 2) -> None:


### PR DESCRIPTION
If a cached sync function calls another cached sync function we now raise an error since otherwise we can cause a dead lock.

In general, we should deprecate sync function caching altogether in the near future.