### PR TITLE
feat: add configurable on-cache-hit hooks to gcache

### DIFF
--- a/src/gcache/__init__.py
+++ b/src/gcache/__init__.py
@@ -1,4 +1,29 @@
-from gcache.config import CacheConfigProvider, CacheLayer, GCacheConfig, GCacheKey, GCacheKeyConfig, RedisConfig
+from gcache.config import (
+    CacheCallContext,
+    CacheConfigProvider,
+    CacheHitDecision,
+    CacheHitHook,
+    CacheLayer,
+    EvictAndFallback,
+    GCacheConfig,
+    GCacheKey,
+    GCacheKeyConfig,
+    RedisConfig,
+    ReturnCached,
+)
 from gcache.gcache import GCache
 
-__all__ = ["CacheConfigProvider", "CacheLayer", "GCache", "GCacheConfig", "GCacheKey", "GCacheKeyConfig", "RedisConfig"]
+__all__ = [
+    "CacheCallContext",
+    "CacheConfigProvider",
+    "CacheHitDecision",
+    "CacheHitHook",
+    "CacheLayer",
+    "EvictAndFallback",
+    "GCache",
+    "GCacheConfig",
+    "GCacheKey",
+    "GCacheKeyConfig",
+    "RedisConfig",
+    "ReturnCached",
+]

--- a/src/gcache/_internal/cache_hit.py
+++ b/src/gcache/_internal/cache_hit.py
@@ -1,0 +1,72 @@
+import inspect
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from gcache._internal.metrics import GCacheMetrics
+from gcache._internal.state import _GLOBAL_GCACHE_STATE
+from gcache.config import CacheCallContext, CacheHitHook, CacheLayer, EvictAndFallback, GCacheKey, ReturnCached
+
+
+@dataclass(frozen=True, slots=True)
+class BypassCurrentLayer:
+    """Internal signal to skip a cache layer without mutating its stored value."""
+
+
+async def run_cache_hit_hook(
+    *,
+    key: GCacheKey,
+    layer: CacheLayer,
+    value: Any,
+    call_args: Mapping[str, Any] | None,
+    on_cache_hit: CacheHitHook | None,
+) -> ReturnCached | EvictAndFallback | BypassCurrentLayer:
+    if on_cache_hit is None:
+        return ReturnCached()
+
+    context = CacheCallContext(key=key, layer=layer, call_args=call_args or {})
+
+    try:
+        decision = on_cache_hit(context, value)
+        if inspect.isawaitable(decision):
+            decision = await decision
+    except Exception:
+        _GLOBAL_GCACHE_STATE.logger.error(
+            "Error executing cache hit hook",
+            extra={"use_case": key.use_case, "key_type": key.key_type, "layer": layer.name},
+            exc_info=True,
+        )
+        GCacheMetrics.HIT_HOOK_ERROR_COUNTER.labels(key.use_case, key.key_type, layer.name).inc()
+        return BypassCurrentLayer()
+
+    if isinstance(decision, ReturnCached):
+        GCacheMetrics.HIT_HOOK_ACTION_COUNTER.labels(
+            key.use_case,
+            key.key_type,
+            layer.name,
+            "return",
+            "none",
+        ).inc()
+        return decision
+
+    if isinstance(decision, EvictAndFallback):
+        GCacheMetrics.HIT_HOOK_ACTION_COUNTER.labels(
+            key.use_case,
+            key.key_type,
+            layer.name,
+            "evict",
+            decision.reason or "none",
+        ).inc()
+        return decision
+
+    _GLOBAL_GCACHE_STATE.logger.error(
+        "Cache hit hook returned invalid decision type",
+        extra={
+            "use_case": key.use_case,
+            "key_type": key.key_type,
+            "layer": layer.name,
+            "decision_type": type(decision).__name__,
+        },
+    )
+    GCacheMetrics.HIT_HOOK_ERROR_COUNTER.labels(key.use_case, key.key_type, layer.name).inc()
+    return BypassCurrentLayer()

--- a/src/gcache/_internal/cache_hit.py
+++ b/src/gcache/_internal/cache_hit.py
@@ -1,5 +1,4 @@
 import inspect
-from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -30,7 +29,6 @@ async def run_cache_hit_hook(
     key: GCacheKey,
     layer: CacheLayer,
     value: Any,
-    call_args: Mapping[str, Any] | None,
     on_cache_hit: CacheHitHook | None,
 ) -> ReturnCached | EvictAndFallback | BypassCurrentLayer:
     """
@@ -43,7 +41,7 @@ async def run_cache_hit_hook(
     if on_cache_hit is None:
         return ReturnCached()
 
-    context = CacheCallContext(key=key, layer=layer, call_args=call_args or {})
+    context = CacheCallContext(key=key, layer=layer)
 
     try:
         decision = on_cache_hit(context, value)

--- a/src/gcache/_internal/cache_hit.py
+++ b/src/gcache/_internal/cache_hit.py
@@ -10,7 +10,19 @@ from gcache.config import CacheCallContext, CacheHitHook, CacheLayer, EvictAndFa
 
 @dataclass(frozen=True, slots=True)
 class BypassCurrentLayer:
-    """Internal signal to skip a cache layer without mutating its stored value."""
+    """
+    Internal signal to ignore this layer for the current request only.
+
+    This is used when the hook machinery is unreliable rather than the cached
+    value itself being known-bad. Two cases currently map here:
+    - the hook raised an exception
+    - the hook returned an unsupported decision type
+
+    In those situations we want fail-open behavior:
+    - do not fail the caller request
+    - do not evict the cached value, because the problem may be in the hook
+    - continue through the normal fallback chain as if this layer had no usable hit
+    """
 
 
 async def run_cache_hit_hook(
@@ -21,6 +33,13 @@ async def run_cache_hit_hook(
     call_args: Mapping[str, Any] | None,
     on_cache_hit: CacheHitHook | None,
 ) -> ReturnCached | EvictAndFallback | BypassCurrentLayer:
+    """
+    Execute the optional cache-hit hook and normalize the result.
+
+    Returning `BypassCurrentLayer` is reserved for hook execution/contract
+    failures. It lets cache layers skip a hit without deleting it, which keeps
+    hook bugs from turning into request failures or unnecessary evictions.
+    """
     if on_cache_hit is None:
         return ReturnCached()
 

--- a/src/gcache/_internal/cache_interface.py
+++ b/src/gcache/_internal/cache_interface.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from gcache.config import CacheConfigProvider, CacheHitHook, CacheLayer, GCacheKey, GCacheKeyConfig
@@ -31,7 +31,6 @@ class CacheInterface(ABC):
         key: GCacheKey,
         fallback: Fallback,
         *,
-        call_args: Mapping[str, Any] | None = None,
         on_cache_hit: CacheHitHook | None = None,
     ) -> Any:
         pass

--- a/src/gcache/_internal/cache_interface.py
+++ b/src/gcache/_internal/cache_interface.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
-from gcache.config import CacheConfigProvider, CacheLayer, GCacheKey, GCacheKeyConfig
+from gcache.config import CacheConfigProvider, CacheHitHook, CacheLayer, GCacheKey, GCacheKeyConfig
 
 #: Async callable that fetches the actual value on cache miss.
 #: Invoked by cache implementations when the requested key is not found or is stale.
@@ -26,7 +26,14 @@ class CacheInterface(ABC):
         return config
 
     @abstractmethod
-    async def get(self, key: GCacheKey, fallback: Fallback) -> Any:
+    async def get(
+        self,
+        key: GCacheKey,
+        fallback: Fallback,
+        *,
+        call_args: Mapping[str, Any] | None = None,
+        on_cache_hit: CacheHitHook | None = None,
+    ) -> Any:
         pass
 
     @abstractmethod

--- a/src/gcache/_internal/local_cache.py
+++ b/src/gcache/_internal/local_cache.py
@@ -1,5 +1,4 @@
 import asyncio
-from collections.abc import Mapping
 from typing import Any
 
 from cachetools import TTLCache
@@ -56,7 +55,6 @@ class LocalCache(CacheInterface):
         key: GCacheKey,
         fallback: Fallback,
         *,
-        call_args: Mapping[str, Any] | None = None,
         on_cache_hit: CacheHitHook | None = None,
     ) -> Any:
         _GLOBAL_GCACHE_STATE.logger.debug("Calling local cache")
@@ -71,7 +69,6 @@ class LocalCache(CacheInterface):
             key=key,
             layer=self.layer(),
             value=cached_value,
-            call_args=call_args,
             on_cache_hit=on_cache_hit,
         )
         if isinstance(decision, ReturnCached):

--- a/src/gcache/_internal/local_cache.py
+++ b/src/gcache/_internal/local_cache.py
@@ -1,12 +1,14 @@
 import asyncio
+from collections.abc import Mapping
 from typing import Any
 
 from cachetools import TTLCache
 
+from gcache._internal.cache_hit import BypassCurrentLayer, run_cache_hit_hook
 from gcache._internal.cache_interface import CacheInterface, Fallback
 from gcache._internal.constants import LOCAL_CACHE_MAX_SIZE
 from gcache._internal.state import _GLOBAL_GCACHE_STATE
-from gcache.config import CacheConfigProvider, CacheLayer, GCacheKey
+from gcache.config import CacheConfigProvider, CacheHitHook, CacheLayer, EvictAndFallback, GCacheKey, ReturnCached
 from gcache.exceptions import MissingKeyConfig
 
 
@@ -44,12 +46,35 @@ class LocalCache(CacheInterface):
 
         return cache
 
-    async def get(self, key: GCacheKey, fallback: Fallback) -> Any:
+    async def get(
+        self,
+        key: GCacheKey,
+        fallback: Fallback,
+        *,
+        call_args: Mapping[str, Any] | None = None,
+        on_cache_hit: CacheHitHook | None = None,
+    ) -> Any:
         _GLOBAL_GCACHE_STATE.logger.debug("Calling local cache")
         cache = await self._get_ttl_cache(key)
 
         if key not in cache:
             await self.put(key, await fallback())
+            return cache[key]
+
+        decision = await run_cache_hit_hook(
+            key=key,
+            layer=self.layer(),
+            value=cache[key],
+            call_args=call_args,
+            on_cache_hit=on_cache_hit,
+        )
+        if isinstance(decision, ReturnCached):
+            return cache[key]
+        if isinstance(decision, EvictAndFallback):
+            cache.pop(key, None)
+            return await fallback()
+        if isinstance(decision, BypassCurrentLayer):
+            return await fallback()
 
         return cache[key]
 

--- a/src/gcache/_internal/local_cache.py
+++ b/src/gcache/_internal/local_cache.py
@@ -46,6 +46,11 @@ class LocalCache(CacheInterface):
 
         return cache
 
+    async def _exec_fallback(self, key: GCacheKey, fallback: Fallback) -> Any:
+        value = await fallback()
+        await self.put(key, value)
+        return value
+
     async def get(
         self,
         key: GCacheKey,
@@ -58,25 +63,26 @@ class LocalCache(CacheInterface):
         cache = await self._get_ttl_cache(key)
 
         if key not in cache:
-            await self.put(key, await fallback())
-            return cache[key]
+            return await self._exec_fallback(key, fallback)
+
+        cached_value = cache[key]
 
         decision = await run_cache_hit_hook(
             key=key,
             layer=self.layer(),
-            value=cache[key],
+            value=cached_value,
             call_args=call_args,
             on_cache_hit=on_cache_hit,
         )
         if isinstance(decision, ReturnCached):
-            return cache[key]
+            return cached_value
         if isinstance(decision, EvictAndFallback):
             cache.pop(key, None)
-            return await fallback()
+            return await self._exec_fallback(key, fallback)
         if isinstance(decision, BypassCurrentLayer):
             return await fallback()
 
-        return cache[key]
+        return cached_value
 
     async def put(self, key: GCacheKey, value: Any) -> None:
         (await self._get_ttl_cache(key))[key] = value

--- a/src/gcache/_internal/metrics.py
+++ b/src/gcache/_internal/metrics.py
@@ -12,6 +12,8 @@ class GCacheMetrics:
     REQUEST_COUNTER: Counter
     ERROR_COUNTER: Counter
     INVALIDATION_COUNTER: Counter
+    HIT_HOOK_ACTION_COUNTER: Counter
+    HIT_HOOK_ERROR_COUNTER: Counter
 
     # Histograms
     GET_TIMER: Histogram
@@ -53,6 +55,18 @@ class GCacheMetrics:
             name=prefix + "gcache_invalidation_counter",
             labelnames=["key_type", "layer"],
             documentation="Cache invalidation counter",
+        )
+
+        cls.HIT_HOOK_ACTION_COUNTER = Counter(
+            name=prefix + "gcache_hit_hook_action_counter",
+            labelnames=["use_case", "key_type", "layer", "action", "reason"],
+            documentation="Cache hit hook action counter",
+        )
+
+        cls.HIT_HOOK_ERROR_COUNTER = Counter(
+            name=prefix + "gcache_hit_hook_error_counter",
+            labelnames=["use_case", "key_type", "layer"],
+            documentation="Cache hit hook error counter",
         )
 
         cls.GET_TIMER = Histogram(

--- a/src/gcache/_internal/noop_cache.py
+++ b/src/gcache/_internal/noop_cache.py
@@ -1,4 +1,3 @@
-from collections.abc import Mapping
 from typing import Any
 
 from gcache._internal.cache_interface import CacheInterface, Fallback
@@ -15,7 +14,6 @@ class NoopCache(CacheInterface):
         key: GCacheKey,
         fallback: Fallback,
         *,
-        call_args: Mapping[str, Any] | None = None,
         on_cache_hit: CacheHitHook | None = None,
     ) -> Any:
         return await fallback()

--- a/src/gcache/_internal/noop_cache.py
+++ b/src/gcache/_internal/noop_cache.py
@@ -1,7 +1,8 @@
+from collections.abc import Mapping
 from typing import Any
 
 from gcache._internal.cache_interface import CacheInterface, Fallback
-from gcache.config import CacheLayer, GCacheKey
+from gcache.config import CacheHitHook, CacheLayer, GCacheKey
 
 
 class NoopCache(CacheInterface):
@@ -9,7 +10,14 @@ class NoopCache(CacheInterface):
     NOOP Cache that does nothing but invoke fallback on get.
     """
 
-    async def get(self, key: GCacheKey, fallback: Fallback) -> Any:
+    async def get(
+        self,
+        key: GCacheKey,
+        fallback: Fallback,
+        *,
+        call_args: Mapping[str, Any] | None = None,
+        on_cache_hit: CacheHitHook | None = None,
+    ) -> Any:
         return await fallback()
 
     async def put(self, key: GCacheKey, value: Any) -> None:

--- a/src/gcache/_internal/redis_cache.py
+++ b/src/gcache/_internal/redis_cache.py
@@ -185,7 +185,7 @@ class RedisCache(CacheInterface):
             )
             if isinstance(decision, EvictAndFallback):
                 await self.delete(key)
-                return await fallback()
+                return await self._exec_fallback(key, watermark_ms, fallback)
             if isinstance(decision, BypassCurrentLayer):
                 return await fallback()
             if not isinstance(decision, ReturnCached):

--- a/src/gcache/_internal/redis_cache.py
+++ b/src/gcache/_internal/redis_cache.py
@@ -2,18 +2,27 @@ import asyncio
 import pickle
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from concurrent.futures.thread import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any
 
 from redis.asyncio import Redis, RedisCluster
 
+from gcache._internal.cache_hit import BypassCurrentLayer, run_cache_hit_hook
 from gcache._internal.cache_interface import CacheInterface, Fallback
 from gcache._internal.constants import ASYNC_PICKLE_THRESHOLD_BYTES, WATERMARK_TTL_SECONDS
 from gcache._internal.metrics import GCacheMetrics
 from gcache._internal.state import _GLOBAL_GCACHE_STATE
-from gcache.config import CacheConfigProvider, CacheLayer, GCacheKey, RedisConfig
+from gcache.config import (
+    CacheConfigProvider,
+    CacheHitHook,
+    CacheLayer,
+    EvictAndFallback,
+    GCacheKey,
+    RedisConfig,
+    ReturnCached,
+)
 from gcache.exceptions import MissingKeyConfig
 
 
@@ -128,7 +137,14 @@ class RedisCache(CacheInterface):
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(RedisCache._executor, pickle.loads, data)
 
-    async def get(self, key: GCacheKey, fallback: Fallback) -> Any:
+    async def get(
+        self,
+        key: GCacheKey,
+        fallback: Fallback,
+        *,
+        call_args: Mapping[str, Any] | None = None,
+        on_cache_hit: CacheHitHook | None = None,
+    ) -> Any:
         _GLOBAL_GCACHE_STATE.logger.debug("Calling Redis Cache")
 
         watermark_ms = None
@@ -159,6 +175,21 @@ class RedisCache(CacheInterface):
                     time.monotonic() - start_sec
                 )
             )
+
+            decision = await run_cache_hit_hook(
+                key=key,
+                layer=self.layer(),
+                value=payload,
+                call_args=call_args,
+                on_cache_hit=on_cache_hit,
+            )
+            if isinstance(decision, EvictAndFallback):
+                await self.delete(key)
+                return await fallback()
+            if isinstance(decision, BypassCurrentLayer):
+                return await fallback()
+            if not isinstance(decision, ReturnCached):
+                return await fallback()
 
             # Check if cache val is expired.
             if watermark_ms is not None:

--- a/src/gcache/_internal/redis_cache.py
+++ b/src/gcache/_internal/redis_cache.py
@@ -2,7 +2,7 @@ import asyncio
 import pickle
 import threading
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from concurrent.futures.thread import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any
@@ -142,7 +142,6 @@ class RedisCache(CacheInterface):
         key: GCacheKey,
         fallback: Fallback,
         *,
-        call_args: Mapping[str, Any] | None = None,
         on_cache_hit: CacheHitHook | None = None,
     ) -> Any:
         _GLOBAL_GCACHE_STATE.logger.debug("Calling Redis Cache")
@@ -180,7 +179,6 @@ class RedisCache(CacheInterface):
                 key=key,
                 layer=self.layer(),
                 value=payload,
-                call_args=call_args,
                 on_cache_hit=on_cache_hit,
             )
             if isinstance(decision, EvictAndFallback):

--- a/src/gcache/_internal/redis_cache.py
+++ b/src/gcache/_internal/redis_cache.py
@@ -157,6 +157,9 @@ class RedisCache(CacheInterface):
             val_pickle = await self.client.get(key.urn)
         if val_pickle is not None:
             start_sec = time.monotonic()
+            serialization_timer = GCacheMetrics.SERIALIZATION_TIMER.labels(
+                key.use_case, key.key_type, self.layer().name, "load"
+            )
 
             deserialized_value: RedisValue = (
                 pickle.loads(val_pickle)
@@ -164,16 +167,19 @@ class RedisCache(CacheInterface):
                 else await RedisCache._async_pickle_loads(val_pickle)
             )
 
+            # Ignore invalidated remote entries before payload deserialization or hook execution.
+            if watermark_ms is not None:
+                watermark_ms = int(watermark_ms)
+                if watermark_ms >= deserialized_value.created_at_ms:
+                    serialization_timer.observe(time.monotonic() - start_sec)
+                    return await self._exec_fallback(key, watermark_ms, fallback)
+
             # Load payload using custom serializer if present.
             payload = deserialized_value.payload
             if key.serializer is not None:
                 payload = await key.serializer.load(payload)
 
-            (
-                GCacheMetrics.SERIALIZATION_TIMER.labels(key.use_case, key.key_type, self.layer().name, "load").observe(
-                    time.monotonic() - start_sec
-                )
-            )
+            serialization_timer.observe(time.monotonic() - start_sec)
 
             decision = await run_cache_hit_hook(
                 key=key,
@@ -189,11 +195,6 @@ class RedisCache(CacheInterface):
             if not isinstance(decision, ReturnCached):
                 return await fallback()
 
-            # Check if cache val is expired.
-            if watermark_ms is not None:
-                watermark_ms = int(watermark_ms)
-                if watermark_ms >= deserialized_value.created_at_ms:
-                    return await self._exec_fallback(key, watermark_ms, fallback)
             return payload
         else:
             return await self._exec_fallback(key, watermark_ms, fallback)

--- a/src/gcache/_internal/wrappers.py
+++ b/src/gcache/_internal/wrappers.py
@@ -1,4 +1,5 @@
 import time
+from collections.abc import Mapping
 from enum import Enum
 from random import random
 from typing import Any
@@ -6,7 +7,7 @@ from typing import Any
 from gcache._internal.cache_interface import CacheInterface, Fallback
 from gcache._internal.metrics import GCacheMetrics
 from gcache._internal.state import _GLOBAL_GCACHE_STATE, GCacheContext
-from gcache.config import CacheConfigProvider, CacheLayer, GCacheKey
+from gcache.config import CacheConfigProvider, CacheHitHook, CacheLayer, GCacheKey
 
 
 class CacheWrapper(CacheInterface):
@@ -58,7 +59,14 @@ class CacheController(CacheWrapper):
         super().__init__(cache_config_provider, cache)
         GCacheMetrics.initialize(metrics_prefix)
 
-    async def get(self, key: GCacheKey, fallback: Fallback) -> Any:
+    async def get(
+        self,
+        key: GCacheKey,
+        fallback: Fallback,
+        *,
+        call_args: Mapping[str, Any] | None = None,
+        on_cache_hit: CacheHitHook | None = None,
+    ) -> Any:
         if await self._should_cache(key):
             start_time = time.monotonic()
             fallback_time = 0.0
@@ -84,7 +92,12 @@ class CacheController(CacheWrapper):
                         )
 
                 try:
-                    return await self.wrapped.get(key, instrumented_fallback)
+                    return await self.wrapped.get(
+                        key,
+                        instrumented_fallback,
+                        call_args=call_args,
+                        on_cache_hit=on_cache_hit,
+                    )
                 except Exception as e:
                     _GLOBAL_GCACHE_STATE.logger.error(f"Error getting value from cache: {e}", exc_info=True)
                     GCacheMetrics.ERROR_COUNTER.labels(
@@ -161,11 +174,18 @@ class CacheChain(CacheWrapper):
         super().__init__(cache_config_provider, cache)
         self.fallback_cache = fallback_cache
 
-    async def get(self, key: GCacheKey, fallback: Fallback) -> Any:
+    async def get(
+        self,
+        key: GCacheKey,
+        fallback: Fallback,
+        *,
+        call_args: Mapping[str, Any] | None = None,
+        on_cache_hit: CacheHitHook | None = None,
+    ) -> Any:
         async def cache_fallback() -> Any:
-            return await self.fallback_cache.get(key, fallback)
+            return await self.fallback_cache.get(key, fallback, call_args=call_args, on_cache_hit=on_cache_hit)
 
-        return await self.wrapped.get(key, cache_fallback)
+        return await self.wrapped.get(key, cache_fallback, call_args=call_args, on_cache_hit=on_cache_hit)
 
     async def delete(self, key: GCacheKey) -> bool:
         ret = await self.wrapped.delete(key)

--- a/src/gcache/_internal/wrappers.py
+++ b/src/gcache/_internal/wrappers.py
@@ -1,5 +1,4 @@
 import time
-from collections.abc import Mapping
 from enum import Enum
 from random import random
 from typing import Any
@@ -64,7 +63,6 @@ class CacheController(CacheWrapper):
         key: GCacheKey,
         fallback: Fallback,
         *,
-        call_args: Mapping[str, Any] | None = None,
         on_cache_hit: CacheHitHook | None = None,
     ) -> Any:
         if await self._should_cache(key):
@@ -95,7 +93,6 @@ class CacheController(CacheWrapper):
                     return await self.wrapped.get(
                         key,
                         instrumented_fallback,
-                        call_args=call_args,
                         on_cache_hit=on_cache_hit,
                     )
                 except Exception as e:
@@ -179,13 +176,12 @@ class CacheChain(CacheWrapper):
         key: GCacheKey,
         fallback: Fallback,
         *,
-        call_args: Mapping[str, Any] | None = None,
         on_cache_hit: CacheHitHook | None = None,
     ) -> Any:
         async def cache_fallback() -> Any:
-            return await self.fallback_cache.get(key, fallback, call_args=call_args, on_cache_hit=on_cache_hit)
+            return await self.fallback_cache.get(key, fallback, on_cache_hit=on_cache_hit)
 
-        return await self.wrapped.get(key, cache_fallback, call_args=call_args, on_cache_hit=on_cache_hit)
+        return await self.wrapped.get(key, cache_fallback, on_cache_hit=on_cache_hit)
 
     async def delete(self, key: GCacheKey) -> bool:
         ret = await self.wrapped.delete(key)

--- a/src/gcache/config.py
+++ b/src/gcache/config.py
@@ -1,6 +1,6 @@
 import json
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
 from logging import Logger, LoggerAdapter
@@ -133,13 +133,11 @@ class CacheCallContext:
     """
     Context provided to cache-hit hooks.
 
-    The hook gets the cache key, the layer that produced the hit, and the
-    bound call arguments from the cached function invocation.
+    The hook gets the cache key and the layer that produced the hit.
     """
 
     key: "GCacheKey"
     layer: CacheLayer
-    call_args: Mapping[str, Any]
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/gcache/config.py
+++ b/src/gcache/config.py
@@ -1,10 +1,10 @@
 import json
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from enum import Enum
 from logging import Logger, LoggerAdapter
-from typing import Any, Union
+from typing import Any, TypeAlias, Union
 
 from pydantic import BaseModel, ConfigDict, field_validator
 from redis.asyncio import Redis, RedisCluster
@@ -129,6 +129,40 @@ class Serializer(ABC):
 
 
 @dataclass(frozen=True, slots=True)
+class CacheCallContext:
+    """
+    Context provided to cache-hit hooks.
+
+    The hook gets the cache key, the layer that produced the hit, and the
+    bound call arguments from the cached function invocation.
+    """
+
+    key: "GCacheKey"
+    layer: CacheLayer
+    call_args: Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class ReturnCached:
+    """Return the current cached value unchanged."""
+
+
+@dataclass(frozen=True, slots=True)
+class EvictAndFallback:
+    """
+    Evict the current layer's cached value and continue fallback resolution.
+
+    The reason is intended for low-cardinality logging and metrics.
+    """
+
+    reason: str | None = None
+
+
+CacheHitDecision: TypeAlias = ReturnCached | EvictAndFallback
+CacheHitHook: TypeAlias = Callable[[CacheCallContext, Any], CacheHitDecision | Awaitable[CacheHitDecision]]
+
+
+@dataclass(frozen=True, slots=True)
 class GCacheKey:
     key_type: str
     id: str
@@ -210,6 +244,7 @@ class GCacheConfig(BaseModel):
     metrics_prefix: str = "api_"
     redis_config: RedisConfig | None = None
     redis_client_factory: Callable[[], Redis | RedisCluster] | None = None
+    on_cache_hit: CacheHitHook | None = None
     logger: Logger | LoggerAdapter | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/src/gcache/gcache.py
+++ b/src/gcache/gcache.py
@@ -243,7 +243,6 @@ class GCache:
 
                     bound_args = sig.bind(*args, **kwargs)
                     bound_args.apply_defaults()  # Apply default values if any
-                    call_args = dict(bound_args.arguments)
 
                     if id_arg_name in kwargs:
                         key_id = kwargs[id_arg_name]  # type: ignore[index]
@@ -302,7 +301,7 @@ class GCache:
                     async def f():  # type: ignore[no-untyped-def, misc]
                         return func(*args, **kwargs)
 
-                return await self._cache.get(key, f, call_args=call_args, on_cache_hit=resolved_on_cache_hit)
+                return await self._cache.get(key, f, on_cache_hit=resolved_on_cache_hit)
 
             if inspect.iscoroutinefunction(func):
                 return functools.wraps(func)(async_wrapped)

--- a/src/gcache/gcache.py
+++ b/src/gcache/gcache.py
@@ -5,7 +5,7 @@ import threading
 from collections.abc import Awaitable, Callable, Generator
 from contextlib import contextmanager
 from functools import partial
-from typing import Any
+from typing import Any, Literal
 
 from gcache._internal.event_loop_thread import EventLoopThread, EventLoopThreadPool
 from gcache._internal.local_cache import LocalCache
@@ -15,6 +15,7 @@ from gcache._internal.redis_cache import RedisCache, create_default_redis_client
 from gcache._internal.state import _GLOBAL_GCACHE_STATE, GCacheContext
 from gcache._internal.wrappers import CacheChain, CacheController, DisabledReasons
 from gcache.config import (
+    CacheHitHook,
     GCacheConfig,
     GCacheKey,
     GCacheKeyConfig,
@@ -28,6 +29,13 @@ from gcache.exceptions import (
     UseCaseIsAlreadyRegistered,
     UseCaseNameIsReserved,
 )
+
+
+class _UseGlobalOnCacheHit:
+    """Private sentinel for decorator hooks that inherit the global config hook."""
+
+
+_USE_GLOBAL_ON_CACHE_HIT = _UseGlobalOnCacheHit()
 
 
 class GCache:
@@ -154,6 +162,7 @@ class GCache:
         track_for_invalidation: bool = False,
         default_config: GCacheKeyConfig | None = None,
         serializer: Serializer | None = None,
+        on_cache_hit: CacheHitHook | Literal[False] | _UseGlobalOnCacheHit = _USE_GLOBAL_ON_CACHE_HIT,
     ) -> Any:
         """
         Decorator which caches a function which can be either sync or async.
@@ -175,6 +184,9 @@ class GCache:
         :param serializer: Optional serializer to use to serialize and deserialize cache values.  Care must be taken that
                            the returned value matches the signature of cached function, as otherwise you may get runtime
                            type/attribute errors.
+        :param on_cache_hit: Optional cache-hit hook for this use case. If omitted, the global
+                             hook from GCacheConfig is used. Pass False to explicitly disable the
+                             global hook for this decorator.
         :return:
         """
 
@@ -205,6 +217,7 @@ class GCache:
 
             adapter_for_key = not isinstance(id_arg, str)
             id_arg_name = id_arg[0] if adapter_for_key else id_arg
+            resolved_on_cache_hit = self._resolve_on_cache_hit(on_cache_hit)
 
             # If name of id arg is in arg_adapters then we should include it in the cache key args.
             # Otherwise we should ignore it.
@@ -230,6 +243,7 @@ class GCache:
 
                     bound_args = sig.bind(*args, **kwargs)
                     bound_args.apply_defaults()  # Apply default values if any
+                    call_args = dict(bound_args.arguments)
 
                     if id_arg_name in kwargs:
                         key_id = kwargs[id_arg_name]  # type: ignore[index]
@@ -288,7 +302,7 @@ class GCache:
                     async def f():  # type: ignore[no-untyped-def, misc]
                         return func(*args, **kwargs)
 
-                return await self._cache.get(key, f)
+                return await self._cache.get(key, f, call_args=call_args, on_cache_hit=resolved_on_cache_hit)
 
             if inspect.iscoroutinefunction(func):
                 return functools.wraps(func)(async_wrapped)
@@ -309,6 +323,17 @@ class GCache:
                 return functools.wraps(func)(sync_wrapped)
 
         return decorator
+
+    def _resolve_on_cache_hit(
+        self, on_cache_hit: CacheHitHook | Literal[False] | _UseGlobalOnCacheHit
+    ) -> CacheHitHook | None:
+        if on_cache_hit is _USE_GLOBAL_ON_CACHE_HIT:
+            return self.config.on_cache_hit
+        if on_cache_hit is False:
+            return None
+        if callable(on_cache_hit):
+            return on_cache_hit
+        raise TypeError("on_cache_hit must be callable, False, or omitted to use the global config hook")
 
     async def ainvalidate(self, key_type: str, id: str, future_buffer_ms: int = 0) -> None:
         """

--- a/tests/test_gcache.py
+++ b/tests/test_gcache.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import pickle
@@ -339,6 +340,74 @@ def test_on_cache_hit_exception_bypasses_current_layer(gcache: GCache) -> None:
         assert len(local_cache.caches["test_on_cache_hit_exception_bypasses_current_layer"]) == 1
 
     assert source_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_async_on_cache_hit_hook_is_awaited(gcache: GCache) -> None:
+    source_calls = 0
+    hook_layers: list[CacheLayer] = []
+
+    async def hook(ctx, value):  # type: ignore[no-untyped-def]
+        await asyncio.sleep(0)
+        hook_layers.append(ctx.layer)
+        return ReturnCached()
+
+    @gcache.cached(
+        key_type="Test",
+        id_arg="test",
+        use_case="test_async_on_cache_hit_hook_is_awaited",
+        on_cache_hit=hook,
+    )
+    async def cached_func(test: int) -> int:
+        nonlocal source_calls
+        source_calls += 1
+        return source_calls
+
+    with gcache.enable():
+        assert await cached_func(test=1) == 1
+        assert await cached_func(test=1) == 1
+
+    assert source_calls == 1
+    assert hook_layers == [CacheLayer.LOCAL]
+
+
+def test_invalid_on_cache_hit_decision_bypasses_current_layer(
+    gcache: GCache,
+    cache_config_provider: FakeCacheConfigProvider,
+) -> None:
+    source_calls = 0
+    return_invalid_decision = True
+    use_case = "test_invalid_on_cache_hit_decision_bypasses_current_layer"
+
+    cache_config_provider.configs[use_case] = GCacheKeyConfig(
+        ttl_sec={CacheLayer.LOCAL: 60, CacheLayer.REMOTE: 60},
+        ramp={CacheLayer.LOCAL: 100, CacheLayer.REMOTE: 0},
+    )
+
+    def hook(ctx, value):  # type: ignore[no-untyped-def]
+        if ctx.layer == CacheLayer.LOCAL and return_invalid_decision:
+            return object()
+        return ReturnCached()
+
+    @gcache.cached(
+        key_type="Test",
+        id_arg="test",
+        use_case=use_case,
+        on_cache_hit=hook,
+    )
+    def cached_func(test: int) -> int:
+        nonlocal source_calls
+        source_calls += 1
+        return source_calls
+
+    with gcache.enable():
+        assert cached_func(test=1) == 1
+        assert cached_func(test=1) == 2
+
+        return_invalid_decision = False
+        assert cached_func(test=1) == 1
+
+    assert source_calls == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_gcache.py
+++ b/tests/test_gcache.py
@@ -94,10 +94,10 @@ def test_global_on_cache_hit_inherited(
     reset_global_state: None,
 ) -> None:
     redis_server.flushall()
-    calls: list[tuple[CacheLayer, dict[str, int]]] = []
+    calls: list[CacheLayer] = []
 
     def global_hook(ctx, value):  # type: ignore[no-untyped-def]
-        calls.append((ctx.layer, dict(ctx.call_args)))
+        calls.append(ctx.layer)
         return ReturnCached()
 
     gcache = GCache(
@@ -119,7 +119,7 @@ def test_global_on_cache_hit_inherited(
             assert calls == []
             assert cached_func() == 123
 
-        assert calls == [(CacheLayer.LOCAL, {"test": 123})]
+        assert calls == [CacheLayer.LOCAL]
     finally:
         gcache.__del__()
 

--- a/tests/test_gcache.py
+++ b/tests/test_gcache.py
@@ -239,9 +239,39 @@ def test_local_on_cache_hit_evicts_and_falls_back_to_remote(gcache: GCache) -> N
         cached_value["status"] = "bad"
 
         assert cached_func(test=1) == {"status": "good", "source_calls": 1}
+        assert cached_func(test=1) == {"status": "good", "source_calls": 1}
 
     assert source_calls == 1
-    assert hook_layers == [CacheLayer.LOCAL, CacheLayer.REMOTE]
+    assert hook_layers == [CacheLayer.LOCAL, CacheLayer.REMOTE, CacheLayer.LOCAL]
+
+
+def test_local_on_cache_hit_returns_validated_value_without_reread(gcache: GCache) -> None:
+    use_case = "test_local_on_cache_hit_returns_validated_value_without_reread"
+    hook_calls = 0
+
+    def hook(ctx, value):  # type: ignore[no-untyped-def]
+        nonlocal hook_calls
+        hook_calls += 1
+        if ctx.layer == CacheLayer.LOCAL:
+            local_cache = get_local_cache_for_use_case(gcache, use_case)
+            local_cache.caches[use_case][ctx.key] = {"value": "replaced"}
+        return ReturnCached()
+
+    @gcache.cached(
+        key_type="Test",
+        id_arg="test",
+        use_case=use_case,
+        on_cache_hit=hook,
+    )
+    def cached_func(test: int) -> dict[str, str]:
+        return {"value": "cached"}
+
+    with gcache.enable():
+        assert cached_func(test=1) == {"value": "cached"}
+        assert cached_func(test=1) == {"value": "cached"}
+        assert cached_func(test=1) == {"value": "replaced"}
+
+    assert hook_calls == 2
 
 
 def test_remote_on_cache_hit_evicts_and_falls_back_to_source(
@@ -275,6 +305,8 @@ def test_remote_on_cache_hit_evicts_and_falls_back_to_source(
     with gcache.enable():
         assert cached_func(test=1) == 1
         remote_hit_enabled = True
+        assert cached_func(test=1) == 2
+        remote_hit_enabled = False
         assert cached_func(test=1) == 2
 
     assert source_calls == 2

--- a/tests/test_gcache.py
+++ b/tests/test_gcache.py
@@ -4,7 +4,7 @@ import pickle
 import threading
 from collections.abc import Generator
 from random import random
-from typing import Any
+from typing import Any, cast
 
 import pytest
 import redislite
@@ -41,6 +41,10 @@ def get_func_metric(name: str) -> float:
         if line.startswith(name):
             return float(line.split(" ")[-1])
     return 0
+
+
+def get_local_cache_for_use_case(gcache: GCache, use_case: str) -> LocalCache:
+    return cast(LocalCache, gcache._local_cache.wrapped)
 
 
 def test_gcache_sync(gcache: GCache, redis_server: redislite.Redis, reset_prometheus_registry: Generator) -> None:
@@ -104,6 +108,7 @@ def test_global_on_cache_hit_inherited(
         )
     )
     try:
+
         @gcache.cached(key_type="Test", id_arg="test", use_case="test_global_on_cache_hit_inherited")
         def cached_func(test: int = 123) -> int:
             return test
@@ -144,6 +149,7 @@ def test_decorator_on_cache_hit_overrides_global(
         )
     )
     try:
+
         @gcache.cached(
             key_type="Test",
             id_arg="test",
@@ -184,6 +190,7 @@ def test_decorator_can_disable_global_on_cache_hit(
         )
     )
     try:
+
         @gcache.cached(
             key_type="Test",
             id_arg="test",
@@ -226,8 +233,9 @@ def test_local_on_cache_hit_evicts_and_falls_back_to_remote(gcache: GCache) -> N
     with gcache.enable():
         assert cached_func(test=1) == {"status": "good", "source_calls": 1}
 
-        local_cache = gcache._local_cache.wrapped.caches["test_local_on_cache_hit_evicts_and_falls_back_to_remote"]
-        cached_value = next(iter(local_cache.values()))
+        local_cache = get_local_cache_for_use_case(gcache, "test_local_on_cache_hit_evicts_and_falls_back_to_remote")
+        cached_entries = local_cache.caches["test_local_on_cache_hit_evicts_and_falls_back_to_remote"]
+        cached_value = next(iter(cached_entries.values()))
         cached_value["status"] = "bad"
 
         assert cached_func(test=1) == {"status": "good", "source_calls": 1}
@@ -295,8 +303,8 @@ def test_on_cache_hit_exception_bypasses_current_layer(gcache: GCache) -> None:
         assert cached_func(test=1) == {"source_calls": 1}
         assert cached_func(test=1) == {"source_calls": 1}
 
-        local_cache = gcache._local_cache.wrapped.caches["test_on_cache_hit_exception_bypasses_current_layer"]
-        assert len(local_cache) == 1
+        local_cache = get_local_cache_for_use_case(gcache, "test_on_cache_hit_exception_bypasses_current_layer")
+        assert len(local_cache.caches["test_on_cache_hit_exception_bypasses_current_layer"]) == 1
 
     assert source_calls == 1
 

--- a/tests/test_gcache.py
+++ b/tests/test_gcache.py
@@ -12,11 +12,13 @@ from prometheus_client import generate_latest
 
 from gcache import (
     CacheLayer,
+    EvictAndFallback,
     GCache,
     GCacheConfig,
     GCacheKey,
     GCacheKeyConfig,
     RedisConfig,
+    ReturnCached,
 )
 from gcache._internal.cache_interface import Fallback
 from gcache._internal.local_cache import LocalCache
@@ -79,6 +81,224 @@ def test_gcache_sync(gcache: GCache, redis_server: redislite.Redis, reset_promet
     # We should have 2 keys.  One for 123 and one for 124 args.
     keys = redis_server.keys()
     assert len(keys) == 2
+
+
+def test_global_on_cache_hit_inherited(
+    cache_config_provider: FakeCacheConfigProvider,
+    redis_server: redislite.Redis,
+    reset_global_state: None,
+) -> None:
+    redis_server.flushall()
+    calls: list[tuple[CacheLayer, dict[str, int]]] = []
+
+    def global_hook(ctx, value):  # type: ignore[no-untyped-def]
+        calls.append((ctx.layer, dict(ctx.call_args)))
+        return ReturnCached()
+
+    gcache = GCache(
+        GCacheConfig(
+            cache_config_provider=cache_config_provider,
+            urn_prefix="urn:galileo:test",
+            redis_config=RedisConfig(port=REDIS_PORT),
+            on_cache_hit=global_hook,
+        )
+    )
+    try:
+        @gcache.cached(key_type="Test", id_arg="test", use_case="test_global_on_cache_hit_inherited")
+        def cached_func(test: int = 123) -> int:
+            return test
+
+        with gcache.enable():
+            assert cached_func() == 123
+            assert calls == []
+            assert cached_func() == 123
+
+        assert calls == [(CacheLayer.LOCAL, {"test": 123})]
+    finally:
+        gcache.__del__()
+
+
+def test_decorator_on_cache_hit_overrides_global(
+    cache_config_provider: FakeCacheConfigProvider,
+    redis_server: redislite.Redis,
+    reset_global_state: None,
+) -> None:
+    redis_server.flushall()
+    global_calls: list[CacheLayer] = []
+    decorator_calls: list[CacheLayer] = []
+
+    def global_hook(ctx, value):  # type: ignore[no-untyped-def]
+        global_calls.append(ctx.layer)
+        return ReturnCached()
+
+    def decorator_hook(ctx, value):  # type: ignore[no-untyped-def]
+        decorator_calls.append(ctx.layer)
+        return ReturnCached()
+
+    gcache = GCache(
+        GCacheConfig(
+            cache_config_provider=cache_config_provider,
+            urn_prefix="urn:galileo:test",
+            redis_config=RedisConfig(port=REDIS_PORT),
+            on_cache_hit=global_hook,
+        )
+    )
+    try:
+        @gcache.cached(
+            key_type="Test",
+            id_arg="test",
+            use_case="test_decorator_on_cache_hit_overrides_global",
+            on_cache_hit=decorator_hook,
+        )
+        def cached_func(test: int = 123) -> int:
+            return test
+
+        with gcache.enable():
+            assert cached_func() == 123
+            assert cached_func() == 123
+
+        assert global_calls == []
+        assert decorator_calls == [CacheLayer.LOCAL]
+    finally:
+        gcache.__del__()
+
+
+def test_decorator_can_disable_global_on_cache_hit(
+    cache_config_provider: FakeCacheConfigProvider,
+    redis_server: redislite.Redis,
+    reset_global_state: None,
+) -> None:
+    redis_server.flushall()
+    global_calls: list[CacheLayer] = []
+
+    def global_hook(ctx, value):  # type: ignore[no-untyped-def]
+        global_calls.append(ctx.layer)
+        return ReturnCached()
+
+    gcache = GCache(
+        GCacheConfig(
+            cache_config_provider=cache_config_provider,
+            urn_prefix="urn:galileo:test",
+            redis_config=RedisConfig(port=REDIS_PORT),
+            on_cache_hit=global_hook,
+        )
+    )
+    try:
+        @gcache.cached(
+            key_type="Test",
+            id_arg="test",
+            use_case="test_decorator_can_disable_global_on_cache_hit",
+            on_cache_hit=False,
+        )
+        def cached_func(test: int = 123) -> int:
+            return test
+
+        with gcache.enable():
+            assert cached_func() == 123
+            assert cached_func() == 123
+
+        assert global_calls == []
+    finally:
+        gcache.__del__()
+
+
+def test_local_on_cache_hit_evicts_and_falls_back_to_remote(gcache: GCache) -> None:
+    source_calls = 0
+    hook_layers: list[CacheLayer] = []
+
+    def hook(ctx, value):  # type: ignore[no-untyped-def]
+        hook_layers.append(ctx.layer)
+        if ctx.layer == CacheLayer.LOCAL and value["status"] == "bad":
+            return EvictAndFallback("bad_local_payload")
+        return ReturnCached()
+
+    @gcache.cached(
+        key_type="Test",
+        id_arg="test",
+        use_case="test_local_on_cache_hit_evicts_and_falls_back_to_remote",
+        on_cache_hit=hook,
+    )
+    def cached_func(test: int) -> dict[str, object]:
+        nonlocal source_calls
+        source_calls += 1
+        return {"status": "good", "source_calls": source_calls}
+
+    with gcache.enable():
+        assert cached_func(test=1) == {"status": "good", "source_calls": 1}
+
+        local_cache = gcache._local_cache.wrapped.caches["test_local_on_cache_hit_evicts_and_falls_back_to_remote"]
+        cached_value = next(iter(local_cache.values()))
+        cached_value["status"] = "bad"
+
+        assert cached_func(test=1) == {"status": "good", "source_calls": 1}
+
+    assert source_calls == 1
+    assert hook_layers == [CacheLayer.LOCAL, CacheLayer.REMOTE]
+
+
+def test_remote_on_cache_hit_evicts_and_falls_back_to_source(
+    gcache: GCache,
+    cache_config_provider: FakeCacheConfigProvider,
+) -> None:
+    source_calls = 0
+    remote_hit_enabled = False
+
+    cache_config_provider.configs["test_remote_on_cache_hit_evicts_and_falls_back_to_source"] = GCacheKeyConfig(
+        ttl_sec={CacheLayer.LOCAL: 60, CacheLayer.REMOTE: 60},
+        ramp={CacheLayer.LOCAL: 0, CacheLayer.REMOTE: 100},
+    )
+
+    def hook(ctx, value):  # type: ignore[no-untyped-def]
+        if ctx.layer == CacheLayer.REMOTE and remote_hit_enabled:
+            return EvictAndFallback("force_remote_refetch")
+        return ReturnCached()
+
+    @gcache.cached(
+        key_type="Test",
+        id_arg="test",
+        use_case="test_remote_on_cache_hit_evicts_and_falls_back_to_source",
+        on_cache_hit=hook,
+    )
+    def cached_func(test: int) -> int:
+        nonlocal source_calls
+        source_calls += 1
+        return source_calls
+
+    with gcache.enable():
+        assert cached_func(test=1) == 1
+        remote_hit_enabled = True
+        assert cached_func(test=1) == 2
+
+    assert source_calls == 2
+
+
+def test_on_cache_hit_exception_bypasses_current_layer(gcache: GCache) -> None:
+    source_calls = 0
+
+    def hook(ctx, value):  # type: ignore[no-untyped-def]
+        if ctx.layer == CacheLayer.LOCAL:
+            raise RuntimeError("boom")
+        return ReturnCached()
+
+    @gcache.cached(
+        key_type="Test",
+        id_arg="test",
+        use_case="test_on_cache_hit_exception_bypasses_current_layer",
+        on_cache_hit=hook,
+    )
+    def cached_func(test: int) -> dict[str, object]:
+        nonlocal source_calls
+        source_calls += 1
+        return {"source_calls": source_calls}
+
+    with gcache.enable():
+        assert cached_func(test=1) == {"source_calls": 1}
+        assert cached_func(test=1) == {"source_calls": 1}
+
+        local_cache = gcache._local_cache.wrapped.caches["test_on_cache_hit_exception_bypasses_current_layer"]
+        assert len(local_cache) == 1
+
+    assert source_calls == 1
 
 
 @pytest.mark.asyncio
@@ -327,7 +547,7 @@ def test_error_in_fallback(gcache: GCache) -> None:
 
 def test_error_in_cache(gcache: GCache, cache_config_provider: FakeCacheConfigProvider) -> None:
     class FailingCache(LocalCache):
-        async def get(self, key: GCacheKey, fallback: Fallback) -> None:
+        async def get(self, key: GCacheKey, fallback: Fallback, **kwargs) -> None:  # type: ignore[no-untyped-def]
             raise Exception("I'm giving up!")
 
     gcache._cache = CacheController(FailingCache(cache_config_provider), cache_config_provider)  # type: ignore[assignment]

--- a/tests/test_gcache.py
+++ b/tests/test_gcache.py
@@ -782,6 +782,53 @@ async def test_do_not_write_if_invalidated(
 
 
 @pytest.mark.asyncio
+async def test_invalidation_skips_remote_hook(
+    gcache: GCache,
+    cache_config_provider: FakeCacheConfigProvider,
+) -> None:
+    use_case = "test_invalidation_skips_remote_hook"
+    source_calls = 0
+    remote_hook_calls = 0
+
+    cache_config_provider.configs[use_case] = GCacheKeyConfig(
+        ttl_sec={CacheLayer.LOCAL: 60, CacheLayer.REMOTE: 60},
+        ramp={CacheLayer.LOCAL: 0, CacheLayer.REMOTE: 100},
+    )
+
+    def hook(ctx, value):  # type: ignore[no-untyped-def]
+        nonlocal remote_hook_calls
+        if ctx.layer == CacheLayer.REMOTE:
+            remote_hook_calls += 1
+        return ReturnCached()
+
+    @gcache.cached(
+        key_type="Test",
+        id_arg="test",
+        use_case=use_case,
+        track_for_invalidation=True,
+        on_cache_hit=hook,
+    )
+    async def cached_func(test: int) -> int:
+        nonlocal source_calls
+        source_calls += 1
+        return source_calls
+
+    with gcache.enable():
+        assert await cached_func(123) == 1
+
+        await gcache.ainvalidate("Test", "123")
+        await asyncio.sleep(0.01)
+
+        assert await cached_func(123) == 2
+        assert remote_hook_calls == 0
+
+        assert await cached_func(123) == 2
+
+    assert source_calls == 2
+    assert remote_hook_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_flush_all(gcache: GCache, redis_server: redislite.Redis) -> None:
     with gcache.enable():
         v = 0


### PR DESCRIPTION
## Summary
This PR adds a generic cache-hit hook API to `gcache` so callers can validate a cached value before it is returned. It introduces a global default hook on `GCacheConfig`, while still allowing each `@cached(...)` use case to override that hook or disable it explicitly.

The initial API is intentionally small: hooks can either return the cached value unchanged or evict the current layer and fall back. There is no repair or replacement path in this version.

## What Changed
- add public cache-hit hook types and export them from the package API
- add global `on_cache_hit` support to `GCacheConfig`
- add decorator-level override and explicit disable semantics in `GCache.cached(...)`
- run hook decisions on true cache hits in both local and Redis-backed cache layers
- make `EvictAndFallback` reuse the normal miss/write-back path so evicted layers are rewarmed immediately
- skip hook execution for Redis entries that have already been invalidated by watermark
- add hook action and error metrics
- add tests for global inheritance, decorator override, decorator disable, local eviction fallback, remote eviction fallback, async hooks, invalid hook decisions, and invalidation-plus-hook behavior

## Why
Galileo needs a framework-agnostic extension point for rejecting unsafe cached ORM values, especially detached-and-expired SQLAlchemy objects held in local cache by reference. This PR provides that extension point without making `gcache` aware of SQLAlchemy.

The final behavior is intentionally narrow:
- hooks see only the cache key and layer for a usable cache hit
- invalidated Redis entries are refreshed before any hook runs
- eviction paths behave like normal misses so cache layers rewarm immediately
- detached lazy-load failures remain the responsibility of the callers hook policy, not `gcache` itself

## Testing
- `poetry run pytest tests/`
- `poetry run ruff check src tests`
- `poetry run mypy src`
- `poetry run mypy --package tests --namespace-packages`

## Related Work
- https://app.shortcut.com/galileo/story/57959
- https://app.shortcut.com/galileo/story/57961