### PR TITLE
fix: Skip Codecov upload for Dependabot runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,10 @@ jobs:
       - name: Run Tets
         run: inv test
 
+      # Dependabot-triggered runs cannot access repository secrets, so this
+      # upload would fail with an empty Codecov token.
       - name: Upload Test Coverage Reports
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: codecov/codecov-action@v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- skip the Codecov upload step when the workflow is triggered by dependabot
- keep coverage uploads for normal pushes where repository secrets are available

## Why
The failing Actions run for the Dependabot branch already had \ configured in the workflow, but Dependabot-triggered runs cannot read repository secrets. That leaves the token empty and Codecov returns "Token required because branch is protected".

## Testing
- workflow change only; no local test run