### PR TITLE
feat(ts): add redis ttl cache layer

### DIFF
--- a/packages/gcache-ts/README.md
+++ b/packages/gcache-ts/README.md
@@ -1,6 +1,6 @@
 # @rungalileo/gcache
 
-TypeScript port of GCache. Milestone 1 intentionally ships a usable local-only library first: explicit enabled contexts, stable key construction, local TTL caching, and fail-open behavior.
+TypeScript port of GCache. Milestone 2 ships explicit enabled contexts, stable key construction, local TTL caching, and optional Redis-backed distributed TTL caching with fail-open behavior.
 
 ## Install
 
@@ -32,6 +32,56 @@ const user = await gcache.enable(async () => {
   return await getUser("123");
 });
 ```
+
+## Redis-backed TTL cache
+
+Pass a small Redis command-surface client, or a lazy factory, to enable the read-through chain:
+
+```ts
+import { GCache, GCacheKeyConfig } from "@rungalileo/gcache";
+
+const gcache = new GCache({
+  redis: {
+    client: redisClient, // implements get, del, flushAll/flushall, and setEx/setex/set({ EX })
+    keyPrefix: "gcache:",
+  },
+});
+```
+
+When caching is enabled, reads flow through:
+
+```text
+local cache -> Redis cache -> fallback function
+```
+
+- Local hits return immediately.
+- Local misses try Redis and populate local on a Redis hit.
+- Redis misses call the fallback and write both Redis and local.
+- Redis read/write/delete/flush failures are logged and fail open; fallback results still return when fallback succeeds.
+
+You can also provide `createClient` for lazy client construction:
+
+```ts
+const gcache = new GCache({
+  redis: {
+    createClient: async () => createRedisClient({ url: process.env.REDIS_URL }),
+  },
+});
+```
+
+Redis payloads use a TypeScript-specific JSON envelope, not the Python pickle format:
+
+```ts
+type RedisValueEnvelope = {
+  version: 1;
+  createdAtMs: number;
+  expiresAtMs: number;
+  encoding: "utf8" | "base64";
+  payload: string;
+};
+```
+
+`payload` is produced by the cached function's serializer, or by `JsonSerializer` by default. Custom serializers can return either `string` or `Buffer`; Buffer payloads are base64 encoded in the envelope.
 
 ## Enabled context
 
@@ -69,21 +119,23 @@ const searchPosts = gcache.cached({
 });
 ```
 
-## Milestone 1 scope
+## Milestone 2 scope
 
 Included:
 
 - Local TTL cache
-- Explicit enabled context
-- Explicit key builders
+- Redis TTL cache
+- Local → Redis → fallback read-through chain
+- Lazy Redis client factory support
+- Timestamped, versioned Redis envelope
+- JSON and custom serializer support for Redis values
 - Duplicate and reserved use-case validation
-- `delete` and `flushAll`
+- `delete` and `flushAll` across configured layers
 - Fail-open behavior for key/config/cache errors
 
 Not included yet:
 
-- Redis
+- Targeted invalidation and watermarks
 - Runtime ramp controls
 - Prometheus metrics
-- Targeted invalidation
 - Framework middleware helpers

--- a/packages/gcache-ts/package.json
+++ b/packages/gcache-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rungalileo/gcache",
   "version": "0.1.0",
-  "description": "TypeScript port of GCache, starting with explicit-context local caching.",
+  "description": "TypeScript port of GCache with explicit-context local and Redis TTL caching.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/gcache-ts/src/config.ts
+++ b/packages/gcache-ts/src/config.ts
@@ -1,4 +1,5 @@
 import type { GCacheKey } from "./key.js";
+import type { RedisConfig } from "./internal/redis-cache.js";
 
 export enum CacheLayer {
   NOOP = "noop",
@@ -42,4 +43,5 @@ export interface GCacheConfig {
   readonly urnPrefix?: string;
   readonly logger?: Logger;
   readonly localMaxSize?: number;
+  readonly redis?: RedisConfig;
 }

--- a/packages/gcache-ts/src/gcache.ts
+++ b/packages/gcache-ts/src/gcache.ts
@@ -4,6 +4,7 @@ import { UseCaseIsAlreadyRegisteredError, UseCaseNameIsReservedError } from "./e
 import { GCacheKey, normalizeArgs } from "./key.js";
 import type { Serializer } from "./serializer.js";
 import { LocalCache } from "./internal/local-cache.js";
+import { RedisCache } from "./internal/redis-cache.js";
 
 type Awaitable<T> = T | Promise<T>;
 type CacheableArgs = readonly unknown[];
@@ -29,12 +30,14 @@ export class GCache {
   private readonly configProvider: CacheConfigProvider;
   private readonly urnPrefix: string;
   private readonly logger: Logger;
+  private readonly redisCache: RedisCache | null;
 
   constructor(config: GCacheConfig = {}) {
     this.configProvider = config.cacheConfigProvider ?? defaultConfigProvider;
     this.urnPrefix = config.urnPrefix ?? "urn";
     this.logger = config.logger ?? defaultLogger;
     this.localCache = new LocalCache(this.configProvider, config.localMaxSize ?? DEFAULT_LOCAL_MAX_SIZE);
+    this.redisCache = config.redis === undefined ? null : new RedisCache({ configProvider: this.configProvider, redis: config.redis });
   }
 
   enable<T>(fn: () => Awaitable<T>): Promise<T> {
@@ -76,22 +79,83 @@ export class GCache {
           return await fn(...args);
         }
 
-        try {
-          return await this.localCache.get(key, async () => await fn(...args));
-        } catch (error) {
-          this.logger.error("Error getting value from local cache", error);
-          return await fn(...args);
+        if (this.redisCache === null) {
+          try {
+            return await this.localCache.get(key, async () => await fn(...args));
+          } catch (error) {
+            this.logger.error("Error getting value from local cache", error);
+            return await fn(...args);
+          }
         }
+
+        return await this.getThroughRedisChain(key, async () => await fn(...args));
       };
     };
   }
 
   async delete(key: GCacheKey): Promise<boolean> {
-    return await this.localCache.delete(key);
+    const localDeleted = await this.localCache.delete(key);
+    if (this.redisCache === null) {
+      return localDeleted;
+    }
+
+    try {
+      return (await this.redisCache.delete(key)) || localDeleted;
+    } catch (error) {
+      this.logger.warn("Error deleting value from Redis cache", error);
+      return localDeleted;
+    }
   }
 
   async flushAll(): Promise<void> {
     await this.localCache.flushAll();
+    if (this.redisCache === null) {
+      return;
+    }
+
+    try {
+      await this.redisCache.flushAll();
+    } catch (error) {
+      this.logger.warn("Error flushing Redis cache", error);
+    }
+  }
+
+  private async getThroughRedisChain<T>(key: GCacheKey, fallback: () => Promise<T>): Promise<T> {
+    try {
+      const localHit = await this.localCache.getIfPresent<T>(key);
+      if (localHit !== undefined) {
+        return localHit;
+      }
+    } catch (error) {
+      this.logger.warn("Error getting value from local cache", error);
+    }
+
+    try {
+      const redisHit = await this.redisCache?.get<T>(key);
+      if (redisHit !== undefined) {
+        await this.putLocalFailOpen(key, redisHit);
+        return redisHit;
+      }
+    } catch (error) {
+      this.logger.warn("Error getting value from Redis cache", error);
+    }
+
+    const value = await fallback();
+    try {
+      await this.redisCache?.put(key, value);
+    } catch (error) {
+      this.logger.warn("Error putting value in Redis cache", error);
+    }
+    await this.putLocalFailOpen(key, value);
+    return value;
+  }
+
+  private async putLocalFailOpen<T>(key: GCacheKey, value: T): Promise<void> {
+    try {
+      await this.localCache.put(key, value);
+    } catch (error) {
+      this.logger.warn("Error putting value in local cache", error);
+    }
   }
 
   private registerUseCase(useCase: string): void {

--- a/packages/gcache-ts/src/index.ts
+++ b/packages/gcache-ts/src/index.ts
@@ -11,5 +11,12 @@ export { GCache } from "./gcache.js";
 export type { CachedOptions } from "./gcache.js";
 export { GCacheKey, normalizeArgs } from "./key.js";
 export type { GCacheKeyInit } from "./key.js";
+export type {
+  RedisCommandClient,
+  RedisConfig,
+  RedisClientFactory,
+  RedisStoredValue,
+  RedisValueEnvelope,
+} from "./internal/redis-cache.js";
 export { JsonSerializer } from "./serializer.js";
 export type { Serializer } from "./serializer.js";

--- a/packages/gcache-ts/src/internal/local-cache.ts
+++ b/packages/gcache-ts/src/internal/local-cache.ts
@@ -18,6 +18,17 @@ export class LocalCache {
   ) {}
 
   async get<T>(key: GCacheKey, fallback: Fallback<T>): Promise<T> {
+    const hit = await this.getIfPresent<T>(key);
+    if (hit !== undefined) {
+      return hit;
+    }
+
+    const value = await fallback();
+    await this.put(key, value);
+    return value;
+  }
+
+  async getIfPresent<T>(key: GCacheKey): Promise<T | undefined> {
     const cache = await this.getUseCaseCache(key);
     const now = Date.now();
     const hit = cache.get(key.urn) as LocalEntry<T> | undefined;
@@ -30,9 +41,7 @@ export class LocalCache {
       cache.delete(key.urn);
     }
 
-    const value = await fallback();
-    await this.put(key, value);
-    return value;
+    return undefined;
   }
 
   async put<T>(key: GCacheKey, value: T): Promise<void> {

--- a/packages/gcache-ts/src/internal/redis-cache.ts
+++ b/packages/gcache-ts/src/internal/redis-cache.ts
@@ -1,0 +1,184 @@
+import { CacheLayer, type CacheConfigProvider, type GCacheKeyConfig } from "../config.js";
+import { MissingKeyConfigError } from "../errors.js";
+import type { GCacheKey } from "../key.js";
+import { JsonSerializer, type Serializer } from "../serializer.js";
+
+export type Awaitable<T> = T | Promise<T>;
+export type RedisStoredValue = string | Buffer;
+
+export interface RedisCommandClient {
+  get(key: string): Awaitable<RedisStoredValue | null>;
+  del(key: string): Awaitable<number>;
+  flushAll?(): Awaitable<unknown>;
+  flushall?(): Awaitable<unknown>;
+  setEx?(key: string, ttlSec: number, value: RedisStoredValue): Awaitable<unknown>;
+  setex?(key: string, ttlSec: number, value: RedisStoredValue): Awaitable<unknown>;
+  set?(key: string, value: RedisStoredValue, options: { EX: number }): Awaitable<unknown>;
+}
+
+export type RedisClientFactory = () => Awaitable<RedisCommandClient>;
+
+export interface RedisConfig {
+  readonly client?: RedisCommandClient;
+  readonly createClient?: RedisClientFactory;
+  readonly keyPrefix?: string;
+  readonly serializer?: Serializer<unknown>;
+}
+
+export interface RedisValueEnvelope {
+  readonly version: 1;
+  readonly createdAtMs: number;
+  readonly expiresAtMs: number;
+  readonly encoding: "utf8" | "base64";
+  readonly payload: string;
+}
+
+interface RedisCacheOptions {
+  readonly configProvider: CacheConfigProvider;
+  readonly redis: RedisConfig;
+}
+
+const ENVELOPE_VERSION = 1;
+const defaultSerializer = new JsonSerializer<unknown>();
+
+export class RedisCache {
+  private readonly configProvider: CacheConfigProvider;
+  private readonly keyPrefix: string;
+  private readonly defaultSerializer: Serializer<unknown>;
+  private readonly createClient: RedisClientFactory | null;
+  private clientPromise: Promise<RedisCommandClient> | null;
+
+  constructor(options: RedisCacheOptions) {
+    this.configProvider = options.configProvider;
+    this.keyPrefix = options.redis.keyPrefix ?? "";
+    this.defaultSerializer = options.redis.serializer ?? defaultSerializer;
+
+    if (options.redis.client === undefined && options.redis.createClient === undefined) {
+      throw new Error("Redis config requires either client or createClient");
+    }
+
+    this.createClient = options.redis.createClient ?? null;
+    this.clientPromise = options.redis.client === undefined ? null : Promise.resolve(options.redis.client);
+  }
+
+  async get<T>(key: GCacheKey): Promise<T | undefined> {
+    await this.resolveRemoteTtl(key);
+    const client = await this.resolveClient();
+    const raw = await client.get(this.redisKey(key));
+    if (raw === null) {
+      return undefined;
+    }
+
+    const envelope = this.parseEnvelope(raw);
+    if (envelope.expiresAtMs <= Date.now()) {
+      await client.del(this.redisKey(key));
+      return undefined;
+    }
+
+    return (await this.serializerFor(key).load(this.decodePayload(envelope))) as T;
+  }
+
+  async put<T>(key: GCacheKey, value: T): Promise<void> {
+    const ttlSec = await this.resolveRemoteTtl(key);
+    const client = await this.resolveClient();
+    const now = Date.now();
+    const payload = await this.serializerFor(key).dump(value);
+    const envelope: RedisValueEnvelope = {
+      version: ENVELOPE_VERSION,
+      createdAtMs: now,
+      expiresAtMs: now + ttlSec * 1000,
+      encoding: Buffer.isBuffer(payload) ? "base64" : "utf8",
+      payload: Buffer.isBuffer(payload) ? payload.toString("base64") : payload,
+    };
+
+    await this.setWithTtl(client, this.redisKey(key), JSON.stringify(envelope), ttlSec);
+  }
+
+  async delete(key: GCacheKey): Promise<boolean> {
+    const client = await this.resolveClient();
+    return (await client.del(this.redisKey(key))) > 0;
+  }
+
+  async flushAll(): Promise<void> {
+    const client = await this.resolveClient();
+    const flushAll = client.flushAll ?? client.flushall;
+    if (flushAll === undefined) {
+      throw new Error("Redis client does not implement flushAll/flushall");
+    }
+    await flushAll.call(client);
+  }
+
+  redisKey(key: GCacheKey): string {
+    return `${this.keyPrefix}${key.urn}`;
+  }
+
+  private async resolveClient(): Promise<RedisCommandClient> {
+    if (this.clientPromise === null) {
+      if (this.createClient === null) {
+        throw new Error("Redis client has not been configured");
+      }
+      this.clientPromise = Promise.resolve(this.createClient());
+    }
+    return await this.clientPromise;
+  }
+
+  private serializerFor(key: GCacheKey): Serializer<unknown> {
+    return key.serializer ?? this.defaultSerializer;
+  }
+
+  private decodePayload(envelope: RedisValueEnvelope): string | Buffer {
+    return envelope.encoding === "base64" ? Buffer.from(envelope.payload, "base64") : envelope.payload;
+  }
+
+  private parseEnvelope(raw: RedisStoredValue): RedisValueEnvelope {
+    const parsed = JSON.parse(Buffer.isBuffer(raw) ? raw.toString("utf8") : raw) as Partial<RedisValueEnvelope>;
+    if (
+      parsed.version !== ENVELOPE_VERSION ||
+      typeof parsed.createdAtMs !== "number" ||
+      typeof parsed.expiresAtMs !== "number" ||
+      (parsed.encoding !== "utf8" && parsed.encoding !== "base64") ||
+      typeof parsed.payload !== "string"
+    ) {
+      throw new Error("Invalid GCache Redis envelope");
+    }
+    return parsed as RedisValueEnvelope;
+  }
+
+  private async setWithTtl(
+    client: RedisCommandClient,
+    key: string,
+    value: RedisStoredValue,
+    ttlSec: number,
+  ): Promise<void> {
+    if (client.setEx !== undefined) {
+      await client.setEx(key, ttlSec, value);
+      return;
+    }
+    if (client.setex !== undefined) {
+      await client.setex(key, ttlSec, value);
+      return;
+    }
+    if (client.set !== undefined) {
+      await client.set(key, value, { EX: ttlSec });
+      return;
+    }
+    throw new Error("Redis client does not implement setEx/setex/set");
+  }
+
+  private async resolveRemoteTtl(key: GCacheKey): Promise<number> {
+    const config = await this.resolveConfig(key);
+    const ttlSec = config.ttlSec[CacheLayer.REMOTE];
+    if (ttlSec === undefined || ttlSec <= 0) {
+      throw new MissingKeyConfigError(key.useCase);
+    }
+    return ttlSec;
+  }
+
+  private async resolveConfig(key: GCacheKey): Promise<GCacheKeyConfig> {
+    const config = (await this.configProvider(key)) ?? key.defaultConfig;
+    if (config === null) {
+      throw new MissingKeyConfigError(key.useCase);
+    }
+    return config;
+  }
+}

--- a/packages/gcache-ts/test/gcache-redis.test.ts
+++ b/packages/gcache-ts/test/gcache-redis.test.ts
@@ -1,0 +1,415 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CacheLayer,
+  GCache,
+  GCacheKey,
+  GCacheKeyConfig,
+  type RedisCommandClient,
+  type RedisStoredValue,
+  type RedisValueEnvelope,
+  type Serializer,
+} from "../src/index.js";
+
+class FakeRedis implements RedisCommandClient {
+  readonly values = new Map<string, { value: RedisStoredValue; expiresAtMs: number }>();
+  getCalls = 0;
+  setCalls = 0;
+  delCalls = 0;
+  flushAllCalls = 0;
+  failGet = false;
+  failSet = false;
+  failDel = false;
+  failFlushAll = false;
+
+  async get(key: string): Promise<RedisStoredValue | null> {
+    this.getCalls += 1;
+    if (this.failGet) {
+      throw new Error("redis get failed");
+    }
+
+    const entry = this.values.get(key);
+    if (entry === undefined) {
+      return null;
+    }
+    if (entry.expiresAtMs <= Date.now()) {
+      this.values.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async setEx(key: string, ttlSec: number, value: RedisStoredValue): Promise<void> {
+    this.setCalls += 1;
+    if (this.failSet) {
+      throw new Error("redis set failed");
+    }
+    this.values.set(key, { value, expiresAtMs: Date.now() + ttlSec * 1000 });
+  }
+
+  async del(key: string): Promise<number> {
+    this.delCalls += 1;
+    if (this.failDel) {
+      throw new Error("redis del failed");
+    }
+    return this.values.delete(key) ? 1 : 0;
+  }
+
+  async flushAll(): Promise<void> {
+    this.flushAllCalls += 1;
+    if (this.failFlushAll) {
+      throw new Error("redis flushAll failed");
+    }
+    this.values.clear();
+  }
+
+  raw(key: string): string {
+    const value = this.values.get(key)?.value;
+    if (typeof value !== "string") {
+      throw new Error(`missing string value for ${key}`);
+    }
+    return value;
+  }
+}
+
+const keyFor = (id: string, useCase: string): GCacheKey => new GCacheKey({ keyType: "user_id", id, useCase });
+
+describe("GCache Redis TTL layer", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reads local miss from Redis and populates the local layer", async () => {
+    // Given one process has already written a value into the shared Redis cache.
+    const redis = new FakeRedis();
+    const writer = new GCache({ redis: { client: redis } });
+    let writerCalls = 0;
+    const writeUser = writer.cached({
+      keyType: "user_id",
+      useCase: "RedisLocalPopulate",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: GCacheKeyConfig.enabled(60),
+    })(async (userId: string) => ({ userId, calls: ++writerCalls }));
+    await writer.enable(async () => await writeUser("123"));
+
+    const reader = new GCache({ redis: { client: redis } });
+    let readerCalls = 0;
+    const readUser = reader.cached({
+      keyType: "user_id",
+      useCase: "RedisLocalPopulate",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: GCacheKeyConfig.enabled(60),
+    })(async (userId: string) => ({ userId, calls: ++readerCalls }));
+    redis.getCalls = 0;
+
+    // When a second process reads the same key twice.
+    const first = await reader.enable(async () => await readUser("123"));
+    redis.failGet = true;
+    const second = await reader.enable(async () => await readUser("123"));
+
+    // Then the first read comes from Redis and the second read comes from the populated local cache.
+    expect(first).toEqual({ userId: "123", calls: 1 });
+    expect(second).toEqual({ userId: "123", calls: 1 });
+    expect(readerCalls).toBe(0);
+    expect(redis.getCalls).toBe(1);
+  });
+
+  it("writes Redis misses with a timestamped versioned envelope", async () => {
+    // Given an enabled Redis-backed cache with deterministic time.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-12T17:00:00.000Z"));
+    const redis = new FakeRedis();
+    const gcache = new GCache({ redis: { client: redis, keyPrefix: "gcache:" } });
+    let calls = 0;
+    const getUser = gcache.cached({
+      keyType: "user_id",
+      useCase: "RedisEnvelopeWrite",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: GCacheKeyConfig.enabled(30),
+    })(async (userId: string) => ({ userId, calls: ++calls }));
+
+    // When Redis misses and the fallback succeeds.
+    const value = await gcache.enable(async () => await getUser("123"));
+    const redisKey = `gcache:${keyFor("123", "RedisEnvelopeWrite").urn}`;
+    const envelope = JSON.parse(redis.raw(redisKey)) as RedisValueEnvelope;
+
+    // Then GCache stores the fallback result in a TS-specific Redis envelope with TTL metadata.
+    expect(value).toEqual({ userId: "123", calls: 1 });
+    expect(envelope).toMatchObject({
+      version: 1,
+      createdAtMs: Date.parse("2026-05-12T17:00:00.000Z"),
+      expiresAtMs: Date.parse("2026-05-12T17:00:30.000Z"),
+      encoding: "utf8",
+    });
+    expect(JSON.parse(envelope.payload)).toEqual({ userId: "123", calls: 1 });
+  });
+
+  it("uses a lazy Redis client factory once", async () => {
+    // Given Redis is configured with a client factory instead of an eager client.
+    const redis = new FakeRedis();
+    let factoryCalls = 0;
+    const gcache = new GCache({
+      redis: {
+        createClient: async () => {
+          factoryCalls += 1;
+          return redis;
+        },
+      },
+    });
+    let calls = 0;
+    const getUser = gcache.cached({
+      keyType: "user_id",
+      useCase: "RedisClientFactory",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: GCacheKeyConfig.enabled(60),
+    })(async (userId: string) => ({ userId, calls: ++calls }));
+
+    // When multiple cache operations need Redis.
+    await gcache.enable(async () => {
+      await getUser("123");
+      await getUser("456");
+    });
+
+    // Then the factory is lazy and reused for subsequent Redis commands.
+    expect(factoryCalls).toBe(1);
+    expect(redis.setCalls).toBe(2);
+  });
+
+  it("fails open when Redis operations fail before fallback", async () => {
+    // Given Redis is unavailable and local caching is not configured for this key.
+    const redis = new FakeRedis();
+    redis.failGet = true;
+    redis.failSet = true;
+    const logger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const gcache = new GCache({ redis: { client: redis }, logger });
+    let calls = 0;
+    const getUser = gcache.cached({
+      keyType: "user_id",
+      useCase: "RedisFailOpen",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: new GCacheKeyConfig({
+        ttlSec: { [CacheLayer.LOCAL]: 0, [CacheLayer.REMOTE]: 60 },
+        ramp: { [CacheLayer.LOCAL]: 100, [CacheLayer.REMOTE]: 100 },
+      }),
+    })(async (userId: string) => ({ userId, calls: ++calls }));
+
+    // When the cached function is called while cache reads and writes fail.
+    const first = await gcache.enable(async () => await getUser("123"));
+    const second = await gcache.enable(async () => await getUser("123"));
+
+    // Then application fallback results are still returned and no Redis error escapes.
+    expect(first).toEqual({ userId: "123", calls: 1 });
+    expect(second).toEqual({ userId: "123", calls: 2 });
+    expect(logger.warn).toHaveBeenCalledWith("Error getting value from Redis cache", expect.any(Error));
+    expect(logger.warn).toHaveBeenCalledWith("Error putting value in Redis cache", expect.any(Error));
+  });
+
+  it("round-trips Redis values through a custom serializer", async () => {
+    // Given a custom serializer is configured for a cached function.
+    const redis = new FakeRedis();
+    const serializer: Serializer<{ id: string; source: string }> = {
+      dump: vi.fn(async (value) => Buffer.from(`${value.id}|${value.source}`, "utf8")),
+      load: vi.fn(async (value) => {
+        const [id, source] = Buffer.isBuffer(value) ? value.toString("utf8").split("|") : value.split("|");
+        return { id: id ?? "", source: source ?? "" };
+      }),
+    };
+    const writer = new GCache({ redis: { client: redis } });
+    const readFromWriter = writer.cached({
+      keyType: "user_id",
+      useCase: "RedisCustomSerializer",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: GCacheKeyConfig.enabled(60),
+      serializer,
+    })(async (userId: string) => ({ id: userId, source: "fallback" }));
+    await writer.enable(async () => await readFromWriter("123"));
+
+    const reader = new GCache({ redis: { client: redis } });
+    let readerCalls = 0;
+    const readFromRedis = reader.cached({
+      keyType: "user_id",
+      useCase: "RedisCustomSerializer",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: GCacheKeyConfig.enabled(60),
+      serializer,
+    })(async (userId: string) => ({ id: userId, source: `fallback-${++readerCalls}` }));
+
+    // When another process reads the value from Redis.
+    const value = await reader.enable(async () => await readFromRedis("123"));
+    const envelope = JSON.parse(redis.raw(keyFor("123", "RedisCustomSerializer").urn)) as RedisValueEnvelope;
+
+    // Then the custom serializer handles the Redis payload instead of JSON serialization.
+    expect(value).toEqual({ id: "123", source: "fallback" });
+    expect(readerCalls).toBe(0);
+    expect(envelope.encoding).toBe("base64");
+    expect(serializer.dump).toHaveBeenCalledOnce();
+    expect(serializer.load).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes stale or malformed Redis envelopes by falling through to fallback", async () => {
+    // Given Redis contains an expired envelope for one key and a malformed envelope for another.
+    const redis = new FakeRedis();
+    const staleKey = keyFor("stale", "RedisBadEnvelope").urn;
+    const badKey = keyFor("bad", "RedisBadEnvelope").urn;
+    redis.values.set(staleKey, {
+      expiresAtMs: Date.now() + 60_000,
+      value: JSON.stringify({
+        version: 1,
+        createdAtMs: Date.now() - 2_000,
+        expiresAtMs: Date.now() - 1_000,
+        encoding: "utf8",
+        payload: JSON.stringify({ stale: true }),
+      } satisfies RedisValueEnvelope),
+    });
+    redis.values.set(badKey, {
+      expiresAtMs: Date.now() + 60_000,
+      value: JSON.stringify({ version: 2, payload: "not valid for v1" }),
+    });
+    const logger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const gcache = new GCache({ redis: { client: redis }, logger });
+    let calls = 0;
+    const getUser = gcache.cached({
+      keyType: "user_id",
+      useCase: "RedisBadEnvelope",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: GCacheKeyConfig.enabled(60),
+    })(async (userId: string) => ({ userId, calls: ++calls }));
+
+    // When both keys are read through the Redis chain.
+    const stale = await gcache.enable(async () => await getUser("stale"));
+    const malformed = await gcache.enable(async () => await getUser("bad"));
+
+    // Then expired entries are deleted, malformed payloads fail open, and fallback results are cached again.
+    expect(stale).toEqual({ userId: "stale", calls: 1 });
+    expect(malformed).toEqual({ userId: "bad", calls: 2 });
+    expect(redis.values.get(staleKey)).toBeDefined();
+    expect(logger.warn).toHaveBeenCalledWith("Error getting value from Redis cache", expect.any(Error));
+  });
+
+  it("fails open when remote config is missing or Redis maintenance commands fail", async () => {
+    // Given Redis is configured but the key has no remote TTL and maintenance commands fail.
+    const redis = new FakeRedis();
+    redis.failDel = true;
+    redis.failFlushAll = true;
+    const logger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const gcache = new GCache({ redis: { client: redis }, logger });
+    let calls = 0;
+    const getUser = gcache.cached({
+      keyType: "user_id",
+      useCase: "RedisMissingRemoteTtl",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: new GCacheKeyConfig({
+        ttlSec: { [CacheLayer.LOCAL]: 0 },
+        ramp: { [CacheLayer.LOCAL]: 100 },
+      }),
+    })(async (userId: string) => ({ userId, calls: ++calls }));
+
+    // When cache reads/writes and explicit maintenance operations cannot use Redis safely.
+    const value = await gcache.enable(async () => await getUser("123"));
+    const deleted = await gcache.delete(keyFor("123", "RedisMissingRemoteTtl"));
+    await gcache.flushAll();
+
+    // Then fallback still succeeds and maintenance failures are logged without escaping.
+    expect(value).toEqual({ userId: "123", calls: 1 });
+    expect(deleted).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith("Error getting value from Redis cache", expect.any(Error));
+    expect(logger.warn).toHaveBeenCalledWith("Error putting value in Redis cache", expect.any(Error));
+    expect(logger.warn).toHaveBeenCalledWith("Error deleting value from Redis cache", expect.any(Error));
+    expect(logger.warn).toHaveBeenCalledWith("Error flushing Redis cache", expect.any(Error));
+  });
+
+  it("supports Redis setex, set with EX, lowercase flushall, and missing-command failures", async () => {
+    // Given lightweight Redis-compatible clients expose different command spellings.
+    const setexValues = new Map<string, RedisStoredValue>();
+    const setexClient: RedisCommandClient = {
+      get: async (key) => setexValues.get(key) ?? null,
+      setex: async (key, _ttlSec, value) => {
+        setexValues.set(key, value);
+      },
+      del: async (key) => (setexValues.delete(key) ? 1 : 0),
+      flushall: async () => setexValues.clear(),
+    };
+    const setValues = new Map<string, RedisStoredValue>();
+    const setClient: RedisCommandClient = {
+      get: async (key) => setValues.get(key) ?? null,
+      set: async (key, value, options) => {
+        expect(options).toEqual({ EX: 60 });
+        setValues.set(key, value);
+      },
+      del: async (key) => (setValues.delete(key) ? 1 : 0),
+      flushAll: async () => setValues.clear(),
+    };
+    const missingSetClient = {
+      get: async () => null,
+      del: async () => 0,
+      flushAll: async () => undefined,
+    } satisfies RedisCommandClient;
+    const logger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    // When values are written through each command shape.
+    for (const [client, useCase] of [
+      [setexClient, "RedisSetexCommand"],
+      [setClient, "RedisSetCommand"],
+      [missingSetClient, "RedisMissingSetCommand"],
+    ] as const) {
+      const gcache = new GCache({ redis: { client }, logger });
+      const getValue = gcache.cached({
+        keyType: "user_id",
+        useCase,
+        id: ([userId]: [string]) => userId,
+        defaultConfig: GCacheKeyConfig.enabled(60),
+      })(async (userId: string) => ({ userId }));
+      await gcache.enable(async () => await getValue("123"));
+      await gcache.flushAll();
+    }
+
+    // Then compatible command spellings work and an incomplete client fails open on writes.
+    expect(setexValues.size).toBe(0);
+    expect(setValues.size).toBe(0);
+    expect(logger.warn).toHaveBeenCalledWith("Error putting value in Redis cache", expect.any(Error));
+  });
+
+  it("rejects Redis config without a client or client factory", () => {
+    // Given a Redis config that cannot create commands.
+    const construct = () => new GCache({ redis: {} });
+
+    // When the cache is constructed, then the invalid Redis configuration is rejected.
+    expect(construct).toThrow("Redis config requires either client or createClient");
+  });
+
+  it("deletes and flushes entries across local and Redis layers", async () => {
+    // Given two cached values exist in both local and Redis layers.
+    const redis = new FakeRedis();
+    const gcache = new GCache({ redis: { client: redis } });
+    let calls = 0;
+    const getUser = gcache.cached({
+      keyType: "user_id",
+      useCase: "RedisDeleteAndFlush",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: GCacheKeyConfig.enabled(60),
+    })(async (userId: string) => ({ userId, calls: ++calls }));
+    await gcache.enable(async () => {
+      await getUser("123");
+      await getUser("456");
+    });
+
+    // When one key is deleted and then all cache layers are flushed.
+    const deleted = await gcache.delete(keyFor("123", "RedisDeleteAndFlush"));
+    const afterDelete = await gcache.enable(async () => [await getUser("123"), await getUser("456")]);
+    await gcache.flushAll();
+    const afterFlush = await gcache.enable(async () => [await getUser("123"), await getUser("456")]);
+
+    // Then delete reaches both layers and flushAll clears both layers.
+    expect(deleted).toBe(true);
+    expect(afterDelete).toEqual([
+      { userId: "123", calls: 3 },
+      { userId: "456", calls: 2 },
+    ]);
+    expect(afterFlush).toEqual([
+      { userId: "123", calls: 4 },
+      { userId: "456", calls: 5 },
+    ]);
+    expect(redis.delCalls).toBeGreaterThanOrEqual(1);
+    expect(redis.flushAllCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add an optional Redis-backed cache layer behind a small command-client interface
- preserve local-only behavior when Redis is not configured, and add local → Redis → fallback read-through when it is
- add versioned timestamped Redis envelopes, default/custom serializer support, cross-layer delete/flushAll, and fail-open Redis error handling
- document Milestone 2 behavior and add Given/When/Then behavioral Redis tests

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm ts:gcache:typecheck`
- `pnpm ts:gcache:test` — 26 tests, coverage: 98.13% statements / 95.27% branches / 100% functions / 98.08% lines
- `pnpm ts:gcache:build`

## Stack
Stacked on #133 / `lev/ts-m1-local-mvp`. This PR intentionally leaves runtime ramp controls, metrics, and targeted invalidation/watermarks for later milestone PRs.
