### PR TITLE
feat(ts): add runtime config ramp controls

### DIFF
--- a/packages/gcache-ts/README.md
+++ b/packages/gcache-ts/README.md
@@ -1,6 +1,6 @@
 # @rungalileo/gcache
 
-TypeScript port of GCache. Milestone 2 ships explicit enabled contexts, stable key construction, local TTL caching, and optional Redis-backed distributed TTL caching with fail-open behavior.
+TypeScript port of GCache. Milestone 3 ships explicit enabled contexts, stable key construction, local/Redis TTL caching, runtime config providers, and gradual rollout ramp controls with fail-open behavior.
 
 ## Install
 
@@ -58,6 +58,7 @@ local cache -> Redis cache -> fallback function
 - Local misses try Redis and populate local on a Redis hit.
 - Redis misses call the fallback and write both Redis and local.
 - Redis read/write/delete/flush failures are logged and fail open; fallback results still return when fallback succeeds.
+- Missing per-layer config disables that layer and falls through to the next layer/fallback.
 
 You can also provide `createClient` for lazy client construction:
 
@@ -82,6 +83,29 @@ type RedisValueEnvelope = {
 ```
 
 `payload` is produced by the cached function's serializer, or by `JsonSerializer` by default. Custom serializers can return either `string` or `Buffer`; Buffer payloads are base64 encoded in the envelope.
+
+## Runtime config and ramp controls
+
+Every cached function can provide a decorator-local `defaultConfig`; a `cacheConfigProvider` can override it at runtime. If the provider returns `null`, GCache falls back to the cached function's `defaultConfig`. If neither exists, or a layer's TTL/ramp is missing or disabled, only that layer is skipped.
+
+```ts
+import { CacheLayer, GCache, GCacheKeyConfig } from "@rungalileo/gcache";
+
+const gcache = new GCache({
+  cacheConfigProvider: async (key) => {
+    if (key.useCase === "GetUser") {
+      return new GCacheKeyConfig({
+        ttlSec: { [CacheLayer.LOCAL]: 30, [CacheLayer.REMOTE]: 300 },
+        ramp: { [CacheLayer.LOCAL]: 100, [CacheLayer.REMOTE]: 25 },
+      });
+    }
+    return null; // use the cached function's defaultConfig
+  },
+  rampSampler: ({ key, layer }) => deterministicPercentFor(`${key.urn}:${layer}`),
+});
+```
+
+`ramp` values are percentages from 0 to 100. `0` disables the layer, `100` enables it, and intermediate values use `rampSampler`; the default sampler is random. Provider errors fail open and execute the fallback function.
 
 ## Enabled context
 
@@ -119,7 +143,7 @@ const searchPosts = gcache.cached({
 });
 ```
 
-## Milestone 2 scope
+## Milestone 3 scope
 
 Included:
 
@@ -132,10 +156,13 @@ Included:
 - Duplicate and reserved use-case validation
 - `delete` and `flushAll` across configured layers
 - Fail-open behavior for key/config/cache errors
+- Runtime config provider with fallback to cached-function `defaultConfig`
+- Per-layer TTL and ramp controls
+- Injectable ramp sampler for deterministic rollout tests
+- Missing config disables only the relevant layer and falls through
 
 Not included yet:
 
 - Targeted invalidation and watermarks
-- Runtime ramp controls
 - Prometheus metrics
 - Framework middleware helpers

--- a/packages/gcache-ts/src/config.ts
+++ b/packages/gcache-ts/src/config.ts
@@ -7,7 +7,18 @@ export enum CacheLayer {
   REMOTE = "remote",
 }
 
+export type Awaitable<T> = T | Promise<T>;
 export type LayerConfig = Partial<Record<CacheLayer, number>>;
+
+export interface CacheRampSample {
+  readonly key: GCacheKey;
+  readonly layer: CacheLayer;
+  readonly ramp: number;
+}
+
+export type CacheRampSampler = (sample: CacheRampSample) => Awaitable<number>;
+
+export const randomRampSampler: CacheRampSampler = () => Math.random() * 100;
 
 export class GCacheKeyConfig {
   readonly ttlSec: LayerConfig;
@@ -44,4 +55,5 @@ export interface GCacheConfig {
   readonly logger?: Logger;
   readonly localMaxSize?: number;
   readonly redis?: RedisConfig;
+  readonly rampSampler?: CacheRampSampler;
 }

--- a/packages/gcache-ts/src/gcache.ts
+++ b/packages/gcache-ts/src/gcache.ts
@@ -1,4 +1,4 @@
-import { GCacheConfig, type CacheConfigProvider, type Logger } from "./config.js";
+import { GCacheConfig, randomRampSampler, type CacheConfigProvider, type CacheRampSampler, type Logger } from "./config.js";
 import { GCacheContext } from "./context.js";
 import { UseCaseIsAlreadyRegisteredError, UseCaseNameIsReservedError } from "./errors.js";
 import { GCacheKey, normalizeArgs } from "./key.js";
@@ -30,14 +30,19 @@ export class GCache {
   private readonly configProvider: CacheConfigProvider;
   private readonly urnPrefix: string;
   private readonly logger: Logger;
+  private readonly rampSampler: CacheRampSampler;
   private readonly redisCache: RedisCache | null;
 
   constructor(config: GCacheConfig = {}) {
     this.configProvider = config.cacheConfigProvider ?? defaultConfigProvider;
     this.urnPrefix = config.urnPrefix ?? "urn";
     this.logger = config.logger ?? defaultLogger;
-    this.localCache = new LocalCache(this.configProvider, config.localMaxSize ?? DEFAULT_LOCAL_MAX_SIZE);
-    this.redisCache = config.redis === undefined ? null : new RedisCache({ configProvider: this.configProvider, redis: config.redis });
+    this.rampSampler = config.rampSampler ?? randomRampSampler;
+    this.localCache = new LocalCache(this.configProvider, this.rampSampler, config.localMaxSize ?? DEFAULT_LOCAL_MAX_SIZE);
+    this.redisCache =
+      config.redis === undefined
+        ? null
+        : new RedisCache({ configProvider: this.configProvider, rampSampler: this.rampSampler, redis: config.redis });
   }
 
   enable<T>(fn: () => Awaitable<T>): Promise<T> {

--- a/packages/gcache-ts/src/index.ts
+++ b/packages/gcache-ts/src/index.ts
@@ -1,5 +1,5 @@
-export { CacheLayer, GCacheKeyConfig } from "./config.js";
-export type { CacheConfigProvider, GCacheConfig, LayerConfig, Logger } from "./config.js";
+export { CacheLayer, GCacheKeyConfig, randomRampSampler } from "./config.js";
+export type { CacheConfigProvider, CacheRampSample, CacheRampSampler, GCacheConfig, LayerConfig, Logger } from "./config.js";
 export { GCacheContext } from "./context.js";
 export {
   GCacheError,

--- a/packages/gcache-ts/src/internal/local-cache.ts
+++ b/packages/gcache-ts/src/internal/local-cache.ts
@@ -1,6 +1,6 @@
-import { CacheLayer, type CacheConfigProvider, type GCacheKeyConfig } from "../config.js";
-import { MissingKeyConfigError } from "../errors.js";
+import { CacheLayer, type CacheConfigProvider, type CacheRampSampler } from "../config.js";
 import type { GCacheKey } from "../key.js";
+import { resolveLayerConfig } from "./runtime-config.js";
 
 export type Fallback<T> = () => Promise<T>;
 
@@ -14,6 +14,7 @@ export class LocalCache {
 
   constructor(
     private readonly configProvider: CacheConfigProvider,
+    private readonly rampSampler: CacheRampSampler,
     private readonly maxSize: number,
   ) {}
 
@@ -29,25 +30,34 @@ export class LocalCache {
   }
 
   async getIfPresent<T>(key: GCacheKey): Promise<T | undefined> {
-    const cache = await this.getUseCaseCache(key);
+    const layerConfig = await this.resolveLocalLayerConfig(key);
+    if (layerConfig === null) {
+      return undefined;
+    }
+
+    const cache = this.caches.get(key.useCase);
     const now = Date.now();
-    const hit = cache.get(key.urn) as LocalEntry<T> | undefined;
+    const hit = cache?.get(key.urn) as LocalEntry<T> | undefined;
 
     if (hit !== undefined && hit.expiresAtMs > now) {
       return hit.value;
     }
 
     if (hit !== undefined) {
-      cache.delete(key.urn);
+      cache?.delete(key.urn);
     }
 
     return undefined;
   }
 
   async put<T>(key: GCacheKey, value: T): Promise<void> {
-    const cache = await this.getUseCaseCache(key);
-    const ttlSec = await this.resolveLocalTtl(key);
-    cache.set(key.urn, { expiresAtMs: Date.now() + ttlSec * 1000, value });
+    const layerConfig = await this.resolveLocalLayerConfig(key);
+    if (layerConfig === null) {
+      return;
+    }
+
+    const cache = this.getOrCreateUseCaseCache(key);
+    cache.set(key.urn, { expiresAtMs: Date.now() + layerConfig.ttlSec * 1000, value });
     this.evictOldestIfNeeded(cache);
   }
 
@@ -60,8 +70,7 @@ export class LocalCache {
     this.caches.clear();
   }
 
-  private async getUseCaseCache(key: GCacheKey): Promise<Map<string, LocalEntry<unknown>>> {
-    await this.resolveLocalTtl(key);
+  private getOrCreateUseCaseCache(key: GCacheKey): Map<string, LocalEntry<unknown>> {
     let cache = this.caches.get(key.useCase);
     if (cache === undefined) {
       cache = new Map<string, LocalEntry<unknown>>();
@@ -70,21 +79,13 @@ export class LocalCache {
     return cache;
   }
 
-  private async resolveLocalTtl(key: GCacheKey): Promise<number> {
-    const config = await this.resolveConfig(key);
-    const ttlSec = config.ttlSec[CacheLayer.LOCAL];
-    if (ttlSec === undefined || ttlSec <= 0) {
-      throw new MissingKeyConfigError(key.useCase);
-    }
-    return ttlSec;
-  }
-
-  private async resolveConfig(key: GCacheKey): Promise<GCacheKeyConfig> {
-    const config = (await this.configProvider(key)) ?? key.defaultConfig;
-    if (config === null) {
-      throw new MissingKeyConfigError(key.useCase);
-    }
-    return config;
+  private async resolveLocalLayerConfig(key: GCacheKey) {
+    return await resolveLayerConfig({
+      configProvider: this.configProvider,
+      key,
+      layer: CacheLayer.LOCAL,
+      rampSampler: this.rampSampler,
+    });
   }
 
   private evictOldestIfNeeded(cache: Map<string, LocalEntry<unknown>>): void {

--- a/packages/gcache-ts/src/internal/redis-cache.ts
+++ b/packages/gcache-ts/src/internal/redis-cache.ts
@@ -1,7 +1,7 @@
-import { CacheLayer, type CacheConfigProvider, type GCacheKeyConfig } from "../config.js";
-import { MissingKeyConfigError } from "../errors.js";
+import { CacheLayer, type CacheConfigProvider, type CacheRampSampler } from "../config.js";
 import type { GCacheKey } from "../key.js";
 import { JsonSerializer, type Serializer } from "../serializer.js";
+import { resolveLayerConfig } from "./runtime-config.js";
 
 export type Awaitable<T> = T | Promise<T>;
 export type RedisStoredValue = string | Buffer;
@@ -35,6 +35,7 @@ export interface RedisValueEnvelope {
 
 interface RedisCacheOptions {
   readonly configProvider: CacheConfigProvider;
+  readonly rampSampler: CacheRampSampler;
   readonly redis: RedisConfig;
 }
 
@@ -43,6 +44,7 @@ const defaultSerializer = new JsonSerializer<unknown>();
 
 export class RedisCache {
   private readonly configProvider: CacheConfigProvider;
+  private readonly rampSampler: CacheRampSampler;
   private readonly keyPrefix: string;
   private readonly defaultSerializer: Serializer<unknown>;
   private readonly createClient: RedisClientFactory | null;
@@ -50,6 +52,7 @@ export class RedisCache {
 
   constructor(options: RedisCacheOptions) {
     this.configProvider = options.configProvider;
+    this.rampSampler = options.rampSampler;
     this.keyPrefix = options.redis.keyPrefix ?? "";
     this.defaultSerializer = options.redis.serializer ?? defaultSerializer;
 
@@ -62,7 +65,11 @@ export class RedisCache {
   }
 
   async get<T>(key: GCacheKey): Promise<T | undefined> {
-    await this.resolveRemoteTtl(key);
+    const layerConfig = await this.resolveRemoteLayerConfig(key);
+    if (layerConfig === null) {
+      return undefined;
+    }
+
     const client = await this.resolveClient();
     const raw = await client.get(this.redisKey(key));
     if (raw === null) {
@@ -79,19 +86,23 @@ export class RedisCache {
   }
 
   async put<T>(key: GCacheKey, value: T): Promise<void> {
-    const ttlSec = await this.resolveRemoteTtl(key);
+    const layerConfig = await this.resolveRemoteLayerConfig(key);
+    if (layerConfig === null) {
+      return;
+    }
+
     const client = await this.resolveClient();
     const now = Date.now();
     const payload = await this.serializerFor(key).dump(value);
     const envelope: RedisValueEnvelope = {
       version: ENVELOPE_VERSION,
       createdAtMs: now,
-      expiresAtMs: now + ttlSec * 1000,
+      expiresAtMs: now + layerConfig.ttlSec * 1000,
       encoding: Buffer.isBuffer(payload) ? "base64" : "utf8",
       payload: Buffer.isBuffer(payload) ? payload.toString("base64") : payload,
     };
 
-    await this.setWithTtl(client, this.redisKey(key), JSON.stringify(envelope), ttlSec);
+    await this.setWithTtl(client, this.redisKey(key), JSON.stringify(envelope), layerConfig.ttlSec);
   }
 
   async delete(key: GCacheKey): Promise<boolean> {
@@ -165,20 +176,12 @@ export class RedisCache {
     throw new Error("Redis client does not implement setEx/setex/set");
   }
 
-  private async resolveRemoteTtl(key: GCacheKey): Promise<number> {
-    const config = await this.resolveConfig(key);
-    const ttlSec = config.ttlSec[CacheLayer.REMOTE];
-    if (ttlSec === undefined || ttlSec <= 0) {
-      throw new MissingKeyConfigError(key.useCase);
-    }
-    return ttlSec;
-  }
-
-  private async resolveConfig(key: GCacheKey): Promise<GCacheKeyConfig> {
-    const config = (await this.configProvider(key)) ?? key.defaultConfig;
-    if (config === null) {
-      throw new MissingKeyConfigError(key.useCase);
-    }
-    return config;
+  private async resolveRemoteLayerConfig(key: GCacheKey) {
+    return await resolveLayerConfig({
+      configProvider: this.configProvider,
+      key,
+      layer: CacheLayer.REMOTE,
+      rampSampler: this.rampSampler,
+    });
   }
 }

--- a/packages/gcache-ts/src/internal/runtime-config.ts
+++ b/packages/gcache-ts/src/internal/runtime-config.ts
@@ -1,0 +1,51 @@
+import { CacheLayer, type CacheConfigProvider, type CacheRampSampler } from "../config.js";
+import type { GCacheKey } from "../key.js";
+
+export interface ResolvedLayerConfig {
+  readonly ttlSec: number;
+  readonly ramp: number;
+}
+
+interface ResolveLayerConfigOptions {
+  readonly configProvider: CacheConfigProvider;
+  readonly key: GCacheKey;
+  readonly layer: CacheLayer;
+  readonly rampSampler: CacheRampSampler;
+}
+
+export async function resolveLayerConfig(options: ResolveLayerConfigOptions): Promise<ResolvedLayerConfig | null> {
+  const config = (await options.configProvider(options.key)) ?? options.key.defaultConfig;
+  if (config === null) {
+    return null;
+  }
+
+  const ttlSec = config.ttlSec[options.layer];
+  if (ttlSec === undefined || ttlSec <= 0) {
+    return null;
+  }
+
+  const ramp = clampPercentage(config.ramp[options.layer] ?? 0);
+  if (ramp <= 0) {
+    return null;
+  }
+  if (ramp >= 100) {
+    return { ttlSec, ramp };
+  }
+
+  const sample = await options.rampSampler({ key: options.key, layer: options.layer, ramp });
+  if (!Number.isFinite(sample)) {
+    return null;
+  }
+
+  return clampPercentage(sample) < ramp ? { ttlSec, ramp } : null;
+}
+
+function clampPercentage(value: number): number {
+  if (value <= 0) {
+    return 0;
+  }
+  if (value >= 100) {
+    return 100;
+  }
+  return value;
+}

--- a/packages/gcache-ts/test/gcache-config-ramp.test.ts
+++ b/packages/gcache-ts/test/gcache-config-ramp.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CacheLayer, GCache, GCacheKeyConfig, type RedisCommandClient, type RedisStoredValue } from "../src/index.js";
+
+class FakeRedis implements RedisCommandClient {
+  readonly values = new Map<string, RedisStoredValue>();
+  getCalls = 0;
+  setCalls = 0;
+
+  async get(key: string): Promise<RedisStoredValue | null> {
+    this.getCalls += 1;
+    return this.values.get(key) ?? null;
+  }
+
+  async setEx(key: string, _ttlSec: number, value: RedisStoredValue): Promise<void> {
+    this.setCalls += 1;
+    this.values.set(key, value);
+  }
+
+  async del(key: string): Promise<number> {
+    return this.values.delete(key) ? 1 : 0;
+  }
+}
+
+const configFor = (ttlSec: Partial<Record<CacheLayer, number>>, ramp: Partial<Record<CacheLayer, number>>) =>
+  new GCacheKeyConfig({ ttlSec, ramp });
+
+describe("GCache runtime config and ramp controls", () => {
+  it("falls back to decorator defaultConfig when the provider returns null", async () => {
+    // Given a runtime config provider that has no dynamic config for this key.
+    const cacheConfigProvider = vi.fn(async () => null);
+    const gcache = new GCache({ cacheConfigProvider });
+    let calls = 0;
+    const getUser = gcache.cached({
+      keyType: "user_id",
+      useCase: "ProviderFallbackDefaultConfig",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: GCacheKeyConfig.enabled(60),
+    })(async (userId: string) => ({ userId, calls: ++calls }));
+
+    // When the same key is read twice inside an enabled scope.
+    const first = await gcache.enable(async () => await getUser("123"));
+    const second = await gcache.enable(async () => await getUser("123"));
+
+    // Then the decorator defaultConfig keeps the local cache active.
+    expect(first).toEqual({ userId: "123", calls: 1 });
+    expect(second).toEqual({ userId: "123", calls: 1 });
+    expect(calls).toBe(1);
+    expect(cacheConfigProvider).toHaveBeenCalled();
+  });
+
+  it("applies runtime config changes to subsequent calls", async () => {
+    // Given a provider whose config can change without redeploying the cached function.
+    let runtimeConfig: GCacheKeyConfig | null = GCacheKeyConfig.enabled(60);
+    const gcache = new GCache({ cacheConfigProvider: async () => runtimeConfig });
+    let calls = 0;
+    const getUser = gcache.cached({
+      keyType: "user_id",
+      useCase: "DynamicProviderConfig",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: GCacheKeyConfig.enabled(60),
+    })(async (userId: string) => ({ userId, calls: ++calls }));
+
+    // When the provider disables local caching after the first cached read.
+    const first = await gcache.enable(async () => await getUser("123"));
+    runtimeConfig = configFor({}, {});
+    const second = await gcache.enable(async () => await getUser("123"));
+
+    // Then the second call honors the new disabled config instead of returning the existing local entry.
+    expect(first).toEqual({ userId: "123", calls: 1 });
+    expect(second).toEqual({ userId: "123", calls: 2 });
+    expect(calls).toBe(2);
+  });
+
+  it("treats ramp 0 and 100 as deterministic layer controls", async () => {
+    // Given one local key is ramped out and another is fully ramped in.
+    const rampSampler = vi.fn(() => {
+      throw new Error("0/100 ramps should not need random sampling");
+    });
+    const gcache = new GCache({ rampSampler });
+    let disabledCalls = 0;
+    const disabled = gcache.cached({
+      keyType: "user_id",
+      useCase: "LocalRampZero",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: configFor({ [CacheLayer.LOCAL]: 60 }, { [CacheLayer.LOCAL]: 0 }),
+    })(async (userId: string) => ({ userId, calls: ++disabledCalls }));
+    let enabledCalls = 0;
+    const enabled = gcache.cached({
+      keyType: "user_id",
+      useCase: "LocalRampHundred",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: configFor({ [CacheLayer.LOCAL]: 60 }, { [CacheLayer.LOCAL]: 100 }),
+    })(async (userId: string) => ({ userId, calls: ++enabledCalls }));
+
+    // When each key is read twice.
+    const disabledFirst = await gcache.enable(async () => await disabled("123"));
+    const disabledSecond = await gcache.enable(async () => await disabled("123"));
+    const enabledFirst = await gcache.enable(async () => await enabled("456"));
+    const enabledSecond = await gcache.enable(async () => await enabled("456"));
+
+    // Then ramp 0 disables the layer, ramp 100 enables it, and neither path samples randomness.
+    expect(disabledFirst).toEqual({ userId: "123", calls: 1 });
+    expect(disabledSecond).toEqual({ userId: "123", calls: 2 });
+    expect(enabledFirst).toEqual({ userId: "456", calls: 1 });
+    expect(enabledSecond).toEqual({ userId: "456", calls: 1 });
+    expect(rampSampler).not.toHaveBeenCalled();
+  });
+
+  it("uses the injected sampler to make ramp 50 behavior testable", async () => {
+    // Given one sampler lands inside ramp 50 and another lands just outside it.
+    const passingSampler = vi.fn(() => 49);
+    const blockedSampler = vi.fn(() => 50);
+    const passingCache = new GCache({ rampSampler: passingSampler });
+    const blockedCache = new GCache({ rampSampler: blockedSampler });
+    let passingCalls = 0;
+    const passing = passingCache.cached({
+      keyType: "user_id",
+      useCase: "LocalRampFiftyPassing",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: configFor({ [CacheLayer.LOCAL]: 60 }, { [CacheLayer.LOCAL]: 50 }),
+    })(async (userId: string) => ({ userId, calls: ++passingCalls }));
+    let blockedCalls = 0;
+    const blocked = blockedCache.cached({
+      keyType: "user_id",
+      useCase: "LocalRampFiftyBlocked",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: configFor({ [CacheLayer.LOCAL]: 60 }, { [CacheLayer.LOCAL]: 50 }),
+    })(async (userId: string) => ({ userId, calls: ++blockedCalls }));
+
+    // When both caches read the same key twice.
+    const passingFirst = await passingCache.enable(async () => await passing("123"));
+    const passingSecond = await passingCache.enable(async () => await passing("123"));
+    const blockedFirst = await blockedCache.enable(async () => await blocked("123"));
+    const blockedSecond = await blockedCache.enable(async () => await blocked("123"));
+
+    // Then the sampled-in key caches and the sampled-out key falls through.
+    expect(passingFirst).toEqual({ userId: "123", calls: 1 });
+    expect(passingSecond).toEqual({ userId: "123", calls: 1 });
+    expect(blockedFirst).toEqual({ userId: "123", calls: 1 });
+    expect(blockedSecond).toEqual({ userId: "123", calls: 2 });
+    expect(passingSampler).toHaveBeenCalledWith(expect.objectContaining({ layer: CacheLayer.LOCAL, ramp: 50 }));
+    expect(blockedSampler).toHaveBeenCalledWith(expect.objectContaining({ layer: CacheLayer.LOCAL, ramp: 50 }));
+  });
+
+  it("uses the injected sampler for remote ramp 50 behavior", async () => {
+    // Given remote-only config with one sampler inside ramp 50 and another just outside it.
+    const passingRedis = new FakeRedis();
+    const blockedRedis = new FakeRedis();
+    const passingSampler = vi.fn(() => 49);
+    const blockedSampler = vi.fn(() => 50);
+    const passingCache = new GCache({
+      redis: { client: passingRedis },
+      rampSampler: passingSampler,
+      cacheConfigProvider: async () => configFor({ [CacheLayer.REMOTE]: 60 }, { [CacheLayer.REMOTE]: 50 }),
+    });
+    const blockedCache = new GCache({
+      redis: { client: blockedRedis },
+      rampSampler: blockedSampler,
+      cacheConfigProvider: async () => configFor({ [CacheLayer.REMOTE]: 60 }, { [CacheLayer.REMOTE]: 50 }),
+    });
+    let passingCalls = 0;
+    const passing = passingCache.cached({
+      keyType: "user_id",
+      useCase: "RemoteRampFiftyPassing",
+      id: ([userId]: [string]) => userId,
+    })(async (userId: string) => ({ userId, calls: ++passingCalls }));
+    let blockedCalls = 0;
+    const blocked = blockedCache.cached({
+      keyType: "user_id",
+      useCase: "RemoteRampFiftyBlocked",
+      id: ([userId]: [string]) => userId,
+    })(async (userId: string) => ({ userId, calls: ++blockedCalls }));
+
+    // When both remote-only caches read the same key twice.
+    const passingFirst = await passingCache.enable(async () => await passing("123"));
+    const passingSecond = await passingCache.enable(async () => await passing("123"));
+    const blockedFirst = await blockedCache.enable(async () => await blocked("123"));
+    const blockedSecond = await blockedCache.enable(async () => await blocked("123"));
+
+    // Then the sampled-in key uses Redis and the sampled-out key never touches Redis.
+    expect(passingFirst).toEqual({ userId: "123", calls: 1 });
+    expect(passingSecond).toEqual({ userId: "123", calls: 1 });
+    expect(blockedFirst).toEqual({ userId: "123", calls: 1 });
+    expect(blockedSecond).toEqual({ userId: "123", calls: 2 });
+    expect(passingRedis.getCalls).toBe(2);
+    expect(passingRedis.setCalls).toBe(1);
+    expect(blockedRedis.getCalls).toBe(0);
+    expect(blockedRedis.setCalls).toBe(0);
+    expect(passingSampler).toHaveBeenCalledWith(expect.objectContaining({ layer: CacheLayer.REMOTE, ramp: 50 }));
+    expect(blockedSampler).toHaveBeenCalledWith(expect.objectContaining({ layer: CacheLayer.REMOTE, ramp: 50 }));
+  });
+
+  it("disables missing local config while allowing the remote layer to work", async () => {
+    // Given runtime config only enables the remote layer.
+    const redis = new FakeRedis();
+    const gcache = new GCache({
+      redis: { client: redis },
+      cacheConfigProvider: async () => configFor({ [CacheLayer.REMOTE]: 60 }, { [CacheLayer.REMOTE]: 100 }),
+    });
+    let calls = 0;
+    const getUser = gcache.cached({
+      keyType: "user_id",
+      useCase: "RemoteOnlyRuntimeConfig",
+      id: ([userId]: [string]) => userId,
+    })(async (userId: string) => ({ userId, calls: ++calls }));
+
+    // When the same key is read twice through a Redis-backed cache.
+    const first = await gcache.enable(async () => await getUser("123"));
+    const second = await gcache.enable(async () => await getUser("123"));
+
+    // Then local is skipped, Redis stores the fallback, and the second read comes from Redis.
+    expect(first).toEqual({ userId: "123", calls: 1 });
+    expect(second).toEqual({ userId: "123", calls: 1 });
+    expect(calls).toBe(1);
+    expect(redis.getCalls).toBe(2);
+    expect(redis.setCalls).toBe(1);
+  });
+
+  it("disables missing remote config while allowing the local layer to work", async () => {
+    // Given Redis exists but runtime config only enables the local layer.
+    const redis = new FakeRedis();
+    const gcache = new GCache({
+      redis: { client: redis },
+      cacheConfigProvider: async () => configFor({ [CacheLayer.LOCAL]: 60 }, { [CacheLayer.LOCAL]: 100 }),
+    });
+    let calls = 0;
+    const getUser = gcache.cached({
+      keyType: "user_id",
+      useCase: "LocalOnlyRuntimeConfig",
+      id: ([userId]: [string]) => userId,
+    })(async (userId: string) => ({ userId, calls: ++calls }));
+
+    // When the same key is read twice through a Redis-backed cache.
+    const first = await gcache.enable(async () => await getUser("123"));
+    const second = await gcache.enable(async () => await getUser("123"));
+
+    // Then Redis is skipped and the second read comes from local cache.
+    expect(first).toEqual({ userId: "123", calls: 1 });
+    expect(second).toEqual({ userId: "123", calls: 1 });
+    expect(calls).toBe(1);
+    expect(redis.getCalls).toBe(0);
+    expect(redis.setCalls).toBe(0);
+  });
+
+  it("fails open when the runtime config provider throws", async () => {
+    // Given the runtime config provider is temporarily unavailable.
+    const providerError = new Error("config provider unavailable");
+    const logger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const gcache = new GCache({
+      logger,
+      cacheConfigProvider: vi.fn(async () => {
+        throw providerError;
+      }),
+    });
+    let calls = 0;
+    const getUser = gcache.cached({
+      keyType: "user_id",
+      useCase: "ConfigProviderThrows",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: GCacheKeyConfig.enabled(60),
+    })(async (userId: string) => ({ userId, calls: ++calls }));
+
+    // When the cached function is called while config lookup fails.
+    const first = await gcache.enable(async () => await getUser("123"));
+    const second = await gcache.enable(async () => await getUser("123"));
+
+    // Then no provider error escapes and no value is accidentally cached.
+    expect(first).toEqual({ userId: "123", calls: 1 });
+    expect(second).toEqual({ userId: "123", calls: 2 });
+    expect(logger.error).toHaveBeenCalledWith("Error getting value from local cache", providerError);
+  });
+});

--- a/packages/gcache-ts/test/gcache-local.test.ts
+++ b/packages/gcache-ts/test/gcache-local.test.ts
@@ -6,7 +6,6 @@ import {
   GCacheKey,
   GCacheKeyConfig,
   JsonSerializer,
-  MissingKeyConfigError,
   UseCaseIsAlreadyRegisteredError,
   UseCaseNameIsReservedError,
 } from "../src/index.js";
@@ -216,7 +215,7 @@ describe("GCache local-only MVP", () => {
     expect(logger.error).toHaveBeenCalledWith("Could not construct GCache key", expect.any(Error));
   });
 
-  it("fails open when local cache config is missing", async () => {
+  it("falls through when local cache config is missing", async () => {
     // Given a cached function without any key config.
     const logger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
     const gcache = new GCache({ logger });
@@ -231,10 +230,11 @@ describe("GCache local-only MVP", () => {
     const first = await gcache.enable(async () => await getUser("123"));
     const second = await gcache.enable(async () => await getUser("123"));
 
-    // Then the fallback still succeeds and the missing config is logged.
+    // Then the local layer is disabled and fallback still succeeds without treating missing config as an error.
     expect(first).toEqual({ userId: "123", calls: 1 });
     expect(second).toEqual({ userId: "123", calls: 2 });
-    expect(logger.error).toHaveBeenCalledWith("Error getting value from local cache", expect.any(MissingKeyConfigError));
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("supports delete and flushAll for local entries", async () => {
@@ -328,7 +328,7 @@ describe("GCache local-only MVP", () => {
     });
   });
 
-  it("treats non-positive local ttl as missing config and fails open", async () => {
+  it("treats non-positive local ttl as disabled local config", async () => {
     // Given a cached function with an invalid local TTL.
     const logger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
     const gcache = new GCache({ logger });
@@ -350,7 +350,8 @@ describe("GCache local-only MVP", () => {
     // Then the local cache is bypassed and the fallback still succeeds.
     expect(first).toEqual({ userId: "123", calls: 1 });
     expect(second).toEqual({ userId: "123", calls: 2 });
-    expect(logger.error).toHaveBeenCalledWith("Error getting value from local cache", expect.any(MissingKeyConfigError));
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("evicts the oldest local entry when max size is exceeded", async () => {

--- a/packages/gcache-ts/test/gcache-redis.test.ts
+++ b/packages/gcache-ts/test/gcache-redis.test.ts
@@ -286,7 +286,7 @@ describe("GCache Redis TTL layer", () => {
     expect(logger.warn).toHaveBeenCalledWith("Error getting value from Redis cache", expect.any(Error));
   });
 
-  it("fails open when remote config is missing or Redis maintenance commands fail", async () => {
+  it("falls through when remote config is missing and fails open on Redis maintenance errors", async () => {
     // Given Redis is configured but the key has no remote TTL and maintenance commands fail.
     const redis = new FakeRedis();
     redis.failDel = true;
@@ -309,11 +309,11 @@ describe("GCache Redis TTL layer", () => {
     const deleted = await gcache.delete(keyFor("123", "RedisMissingRemoteTtl"));
     await gcache.flushAll();
 
-    // Then fallback still succeeds and maintenance failures are logged without escaping.
+    // Then missing remote config disables Redis reads/writes, while maintenance failures are logged without escaping.
     expect(value).toEqual({ userId: "123", calls: 1 });
     expect(deleted).toBe(false);
-    expect(logger.warn).toHaveBeenCalledWith("Error getting value from Redis cache", expect.any(Error));
-    expect(logger.warn).toHaveBeenCalledWith("Error putting value in Redis cache", expect.any(Error));
+    expect(redis.getCalls).toBe(0);
+    expect(redis.setCalls).toBe(0);
     expect(logger.warn).toHaveBeenCalledWith("Error deleting value from Redis cache", expect.any(Error));
     expect(logger.warn).toHaveBeenCalledWith("Error flushing Redis cache", expect.any(Error));
   });


### PR DESCRIPTION
## Summary
- add runtime config resolution for per-layer TTL and ramp controls
- fall back from provider `null` to cached-function `defaultConfig`
- disable only the relevant layer for missing/invalid TTL or ramp config, then continue through the remaining cache chain
- add injectable percentage sampling so ramp behavior is deterministic in tests
- document Milestone 3 scope and add Given/When/Then behavioral tests

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm ts:gcache:typecheck`
- `pnpm ts:gcache:test` — 34 tests, coverage: 96.53% statements / 95.1% branches / 96.82% functions / 96.88% lines
- `pnpm ts:gcache:build`

## Stack
Stacked on #134 / `lev/ts-m2-redis-ttl`. This PR intentionally leaves Prometheus metrics, targeted invalidation/watermarks, and framework integrations for later milestone PRs.
