### PR TITLE
feat(ts): add observability metrics

### DIFF
--- a/packages/gcache-ts/README.md
+++ b/packages/gcache-ts/README.md
@@ -1,6 +1,6 @@
 # @rungalileo/gcache
 
-TypeScript port of GCache. Milestone 3 ships explicit enabled contexts, stable key construction, local/Redis TTL caching, runtime config providers, and gradual rollout ramp controls with fail-open behavior.
+TypeScript port of GCache. Milestone 4 ships explicit enabled contexts, stable key construction, local/Redis TTL caching, runtime config providers, gradual rollout ramp controls, and Prometheus-ready observability with fail-open behavior.
 
 ## Install
 
@@ -57,8 +57,8 @@ local cache -> Redis cache -> fallback function
 - Local hits return immediately.
 - Local misses try Redis and populate local on a Redis hit.
 - Redis misses call the fallback and write both Redis and local.
-- Redis read/write/delete/flush failures are logged and fail open; fallback results still return when fallback succeeds.
-- Missing per-layer config disables that layer and falls through to the next layer/fallback.
+- Redis read/write/delete/flush failures are logged, counted in metrics, and fail open; fallback results still return when fallback succeeds.
+- Missing per-layer config disables that layer, records a disabled reason, and falls through to the next layer/fallback.
 
 You can also provide `createClient` for lazy client construction:
 
@@ -143,7 +143,42 @@ const searchPosts = gcache.cached({
 });
 ```
 
-## Milestone 3 scope
+## Metrics
+
+GCache registers Prometheus metrics by default via `prom-client`. Metric names intentionally follow the Python package where practical:
+
+| Metric | Type | Labels | Description |
+| --- | --- | --- | --- |
+| `gcache_request_counter` | Counter | `use_case`, `key_type`, `layer` | Cache-layer requests that reached an enabled layer |
+| `gcache_miss_counter` | Counter | `use_case`, `key_type`, `layer` | Cache misses |
+| `gcache_disabled_counter` | Counter | `use_case`, `key_type`, `layer`, `reason` | Cache skips (`context`, `missing_config`, `invalid_ttl`, `ramped_down`, `config_error`) |
+| `gcache_error_counter` | Counter | `use_case`, `key_type`, `layer`, `error`, `in_fallback` | Cache/fallback errors, with `in_fallback` separating cache plumbing failures from application fallback failures |
+| `gcache_invalidation_counter` | Counter | `key_type`, `layer` | Delete/invalidation calls for the layers touched today |
+| `gcache_get_timer` | Histogram | `use_case`, `key_type`, `layer` | Cache get latency in seconds |
+| `gcache_fallback_timer` | Histogram | `use_case`, `key_type`, `layer` | Time spent in the underlying function |
+| `gcache_serialization_timer` | Histogram | `use_case`, `key_type`, `layer`, `operation` | Redis serializer dump/load latency |
+| `gcache_size_histogram` | Histogram | `use_case`, `key_type`, `layer` | Serialized Redis payload size in bytes |
+
+Use a custom registry or prefix when embedding GCache in an app with its own metrics endpoint:
+
+```ts
+import { Registry } from "prom-client";
+import { GCache } from "@rungalileo/gcache";
+
+const registry = new Registry();
+const gcache = new GCache({
+  metricsRegistry: registry,
+  metricsPrefix: "myapp_", // myapp_gcache_request_counter, etc.
+});
+
+app.get("/metrics", async (_req, res) => {
+  res.type(registry.contentType).send(await registry.metrics());
+});
+```
+
+For non-Prometheus telemetry, inject a `GCacheMetricsAdapter` through `new GCache({ metrics })`. Pass `metrics: false` to disable metrics entirely. GCache reuses existing collectors in a registry so repeated instances with the same prefix do not throw duplicate-registration errors.
+
+## Milestone 4 scope
 
 Included:
 
@@ -160,9 +195,13 @@ Included:
 - Per-layer TTL and ramp controls
 - Injectable ramp sampler for deterministic rollout tests
 - Missing config disables only the relevant layer and falls through
+- Prometheus metrics with duplicate-registration safety
+- Custom metrics adapter/registry/prefix hooks
+- Cache-vs-fallback error classification through the `in_fallback` label
+- Serialization latency and cached payload size metrics for Redis values
+- Logger injection for cache operational failures
 
 Not included yet:
 
-- Targeted invalidation and watermarks
-- Prometheus metrics
-- Framework middleware helpers
+- Targeted invalidation and watermarks beyond the current `delete`/placeholder invalidation counter
+- Framework middleware helpers/integrations

--- a/packages/gcache-ts/package.json
+++ b/packages/gcache-ts/package.json
@@ -33,5 +33,8 @@
   },
   "engines": {
     "node": ">=18.17"
+  },
+  "dependencies": {
+    "prom-client": "^15.1.3"
   }
 }

--- a/packages/gcache-ts/src/config.ts
+++ b/packages/gcache-ts/src/config.ts
@@ -1,4 +1,7 @@
+import type { Registry } from "prom-client";
+
 import type { GCacheKey } from "./key.js";
+import type { GCacheMetricsAdapter } from "./metrics.js";
 import type { RedisConfig } from "./internal/redis-cache.js";
 
 export enum CacheLayer {
@@ -56,4 +59,7 @@ export interface GCacheConfig {
   readonly localMaxSize?: number;
   readonly redis?: RedisConfig;
   readonly rampSampler?: CacheRampSampler;
+  readonly metrics?: GCacheMetricsAdapter | false;
+  readonly metricsPrefix?: string;
+  readonly metricsRegistry?: Registry;
 }

--- a/packages/gcache-ts/src/gcache.ts
+++ b/packages/gcache-ts/src/gcache.ts
@@ -1,7 +1,10 @@
-import { GCacheConfig, randomRampSampler, type CacheConfigProvider, type CacheRampSampler, type Logger } from "./config.js";
+import { performance } from "node:perf_hooks";
+
+import { CacheLayer, GCacheConfig, randomRampSampler, type CacheConfigProvider, type CacheRampSampler, type Logger } from "./config.js";
 import { GCacheContext } from "./context.js";
 import { UseCaseIsAlreadyRegisteredError, UseCaseNameIsReservedError } from "./errors.js";
 import { GCacheKey, normalizeArgs } from "./key.js";
+import { createPrometheusGCacheMetrics, errorName, labelsFor, type CacheMetricLabels, type GCacheMetricsAdapter } from "./metrics.js";
 import type { Serializer } from "./serializer.js";
 import { LocalCache } from "./internal/local-cache.js";
 import { RedisCache } from "./internal/redis-cache.js";
@@ -32,17 +35,31 @@ export class GCache {
   private readonly logger: Logger;
   private readonly rampSampler: CacheRampSampler;
   private readonly redisCache: RedisCache | null;
+  private readonly metrics: GCacheMetricsAdapter | null;
 
   constructor(config: GCacheConfig = {}) {
     this.configProvider = config.cacheConfigProvider ?? defaultConfigProvider;
     this.urnPrefix = config.urnPrefix ?? "urn";
     this.logger = config.logger ?? defaultLogger;
     this.rampSampler = config.rampSampler ?? randomRampSampler;
+    this.metrics =
+      config.metrics === false
+        ? null
+        : config.metrics ??
+          createPrometheusGCacheMetrics({
+            prefix: config.metricsPrefix ?? "",
+            ...(config.metricsRegistry === undefined ? {} : { registry: config.metricsRegistry }),
+          });
     this.localCache = new LocalCache(this.configProvider, this.rampSampler, config.localMaxSize ?? DEFAULT_LOCAL_MAX_SIZE);
     this.redisCache =
       config.redis === undefined
         ? null
-        : new RedisCache({ configProvider: this.configProvider, rampSampler: this.rampSampler, redis: config.redis });
+        : new RedisCache({
+            configProvider: this.configProvider,
+            rampSampler: this.rampSampler,
+            redis: config.redis,
+            metrics: this.metrics,
+          });
   }
 
   enable<T>(fn: () => Awaitable<T>): Promise<T> {
@@ -73,6 +90,12 @@ export class GCache {
     return <Value>(fn: (...args: Args) => Awaitable<Value>) => {
       return async (...args: Args): Promise<Value> => {
         if (!this.isEnabled()) {
+          this.metrics?.disabled({
+            useCase: options.useCase,
+            keyType: options.keyType,
+            layer: "noop",
+            reason: "context",
+          });
           return await fn(...args);
         }
 
@@ -81,16 +104,18 @@ export class GCache {
           key = this.createKey(options, args);
         } catch (error) {
           this.logger.error("Could not construct GCache key", error);
-          return await fn(...args);
+          this.metrics?.error({
+            useCase: options.useCase,
+            keyType: options.keyType,
+            layer: "noop",
+            error: errorName(error),
+            inFallback: false,
+          });
+          return await this.callFallback({ useCase: options.useCase, keyType: options.keyType, layer: "noop" }, async () => await fn(...args));
         }
 
         if (this.redisCache === null) {
-          try {
-            return await this.localCache.get(key, async () => await fn(...args));
-          } catch (error) {
-            this.logger.error("Error getting value from local cache", error);
-            return await fn(...args);
-          }
+          return await this.getThroughLocalOnly(key, async () => await fn(...args));
         }
 
         return await this.getThroughRedisChain(key, async () => await fn(...args));
@@ -99,15 +124,18 @@ export class GCache {
   }
 
   async delete(key: GCacheKey): Promise<boolean> {
+    this.metrics?.invalidation({ keyType: key.keyType, layer: CacheLayer.LOCAL });
     const localDeleted = await this.localCache.delete(key);
     if (this.redisCache === null) {
       return localDeleted;
     }
 
+    this.metrics?.invalidation({ keyType: key.keyType, layer: CacheLayer.REMOTE });
     try {
       return (await this.redisCache.delete(key)) || localDeleted;
     } catch (error) {
       this.logger.warn("Error deleting value from Redis cache", error);
+      this.recordError(key, CacheLayer.REMOTE, error, false);
       return localDeleted;
     }
   }
@@ -122,37 +150,102 @@ export class GCache {
       await this.redisCache.flushAll();
     } catch (error) {
       this.logger.warn("Error flushing Redis cache", error);
+      this.metrics?.error({
+        useCase: "flushAll",
+        keyType: "all",
+        layer: CacheLayer.REMOTE,
+        error: errorName(error),
+        inFallback: false,
+      });
     }
   }
 
+  private async getThroughLocalOnly<T>(key: GCacheKey, fallback: () => Promise<T>): Promise<T> {
+    const local = await this.readLocal<T>(key);
+    if (local.status === "hit") {
+      return local.value;
+    }
+
+    const value = await this.callFallback(labelsFor(key, CacheLayer.LOCAL), fallback);
+    if (local.status === "miss") {
+      await this.putLocalFailOpen(key, value);
+    }
+    return value;
+  }
+
   private async getThroughRedisChain<T>(key: GCacheKey, fallback: () => Promise<T>): Promise<T> {
-    try {
-      const localHit = await this.localCache.getIfPresent<T>(key);
-      if (localHit !== undefined) {
-        return localHit;
-      }
-    } catch (error) {
-      this.logger.warn("Error getting value from local cache", error);
+    const local = await this.readLocal<T>(key);
+    if (local.status === "hit") {
+      return local.value;
     }
 
-    try {
-      const redisHit = await this.redisCache?.get<T>(key);
-      if (redisHit !== undefined) {
-        await this.putLocalFailOpen(key, redisHit);
-        return redisHit;
-      }
-    } catch (error) {
-      this.logger.warn("Error getting value from Redis cache", error);
+    const remote = await this.readRemote<T>(key);
+    if (remote.status === "hit") {
+      await this.putLocalFailOpen(key, remote.value);
+      return remote.value;
     }
 
-    const value = await fallback();
-    try {
-      await this.redisCache?.put(key, value);
-    } catch (error) {
-      this.logger.warn("Error putting value in Redis cache", error);
+    const remoteErrored = remote.status === "disabled" && remote.reason === "config_error";
+    const fallbackLayer = remote.status === "miss" || remoteErrored ? CacheLayer.REMOTE : CacheLayer.LOCAL;
+    const value = await this.callFallback(labelsFor(key, fallbackLayer), fallback);
+    if (remote.status === "miss" || remoteErrored) {
+      try {
+        await this.redisCache?.put(key, value);
+      } catch (error) {
+        this.logger.warn("Error putting value in Redis cache", error);
+        this.recordError(key, CacheLayer.REMOTE, error, false);
+      }
     }
     await this.putLocalFailOpen(key, value);
     return value;
+  }
+
+  private async readLocal<T>(key: GCacheKey) {
+    const start = performance.now();
+    try {
+      const result = await this.localCache.getIfPresentResult<T>(key);
+      if (result.status === "disabled") {
+        this.metrics?.disabled({ ...labelsFor(key, CacheLayer.LOCAL), reason: result.reason });
+        return result;
+      }
+
+      this.metrics?.request(labelsFor(key, CacheLayer.LOCAL));
+      this.metrics?.observeGet(labelsFor(key, CacheLayer.LOCAL), elapsedSeconds(start));
+      if (result.status === "miss") {
+        this.metrics?.miss(labelsFor(key, CacheLayer.LOCAL));
+      }
+      return result;
+    } catch (error) {
+      this.logger.error("Error getting value from local cache", error);
+      this.recordError(key, CacheLayer.LOCAL, error, false);
+      this.metrics?.disabled({ ...labelsFor(key, CacheLayer.LOCAL), reason: "config_error" });
+      return { status: "disabled", reason: "config_error" } as const;
+    }
+  }
+
+  private async readRemote<T>(key: GCacheKey) {
+    const start = performance.now();
+    try {
+      const result = await this.redisCache?.getResult<T>(key);
+      if (result === undefined) {
+        return { status: "disabled", reason: "missing_config" } as const;
+      }
+      if (result.status === "disabled") {
+        this.metrics?.disabled({ ...labelsFor(key, CacheLayer.REMOTE), reason: result.reason });
+        return result;
+      }
+
+      this.metrics?.request(labelsFor(key, CacheLayer.REMOTE));
+      this.metrics?.observeGet(labelsFor(key, CacheLayer.REMOTE), elapsedSeconds(start));
+      if (result.status === "miss") {
+        this.metrics?.miss(labelsFor(key, CacheLayer.REMOTE));
+      }
+      return result;
+    } catch (error) {
+      this.logger.warn("Error getting value from Redis cache", error);
+      this.recordError(key, CacheLayer.REMOTE, error, false);
+      return { status: "disabled", reason: "config_error" } as const;
+    }
   }
 
   private async putLocalFailOpen<T>(key: GCacheKey, value: T): Promise<void> {
@@ -160,7 +253,24 @@ export class GCache {
       await this.localCache.put(key, value);
     } catch (error) {
       this.logger.warn("Error putting value in local cache", error);
+      this.recordError(key, CacheLayer.LOCAL, error, false);
     }
+  }
+
+  private async callFallback<T>(labels: CacheMetricLabels, fallback: () => Promise<T>): Promise<T> {
+    const start = performance.now();
+    try {
+      return await fallback();
+    } catch (error) {
+      this.metrics?.error({ ...labels, error: errorName(error), inFallback: true });
+      throw error;
+    } finally {
+      this.metrics?.observeFallback(labels, elapsedSeconds(start));
+    }
+  }
+
+  private recordError(key: GCacheKey, layer: CacheLayer, error: unknown, inFallback: boolean): void {
+    this.metrics?.error({ ...labelsFor(key, layer), error: errorName(error), inFallback });
   }
 
   private registerUseCase(useCase: string): void {
@@ -184,4 +294,8 @@ export class GCache {
       serializer: (options.serializer as Serializer<unknown> | null | undefined) ?? null,
     });
   }
+}
+
+function elapsedSeconds(startMs: number): number {
+  return Math.max((performance.now() - startMs) / 1000, 0);
 }

--- a/packages/gcache-ts/src/index.ts
+++ b/packages/gcache-ts/src/index.ts
@@ -1,6 +1,18 @@
 export { CacheLayer, GCacheKeyConfig, randomRampSampler } from "./config.js";
 export type { CacheConfigProvider, CacheRampSample, CacheRampSampler, GCacheConfig, LayerConfig, Logger } from "./config.js";
 export { GCacheContext } from "./context.js";
+export { PrometheusGCacheMetrics, createPrometheusGCacheMetrics } from "./metrics.js";
+export type {
+  CacheMetricLabels,
+  DisabledMetricLabels,
+  DisabledReason,
+  ErrorMetricLabels,
+  GCacheMetricsAdapter,
+  InvalidationMetricLabels,
+  MetricLayer,
+  PrometheusMetricsOptions,
+  SerializationMetricLabels,
+} from "./metrics.js";
 export {
   GCacheError,
   MissingKeyConfigError,

--- a/packages/gcache-ts/src/internal/cache-result.ts
+++ b/packages/gcache-ts/src/internal/cache-result.ts
@@ -1,0 +1,6 @@
+import type { DisabledReason } from "../metrics.js";
+
+export type CacheGetResult<T> =
+  | { readonly status: "hit"; readonly value: T }
+  | { readonly status: "miss" }
+  | { readonly status: "disabled"; readonly reason: DisabledReason };

--- a/packages/gcache-ts/src/internal/local-cache.ts
+++ b/packages/gcache-ts/src/internal/local-cache.ts
@@ -1,6 +1,7 @@
 import { CacheLayer, type CacheConfigProvider, type CacheRampSampler } from "../config.js";
 import type { GCacheKey } from "../key.js";
-import { resolveLayerConfig } from "./runtime-config.js";
+import type { CacheGetResult } from "./cache-result.js";
+import { resolveLayerConfigResult } from "./runtime-config.js";
 
 export type Fallback<T> = () => Promise<T>;
 
@@ -19,20 +20,27 @@ export class LocalCache {
   ) {}
 
   async get<T>(key: GCacheKey, fallback: Fallback<T>): Promise<T> {
-    const hit = await this.getIfPresent<T>(key);
-    if (hit !== undefined) {
-      return hit;
+    const result = await this.getIfPresentResult<T>(key);
+    if (result.status === "hit") {
+      return result.value;
     }
 
     const value = await fallback();
-    await this.put(key, value);
+    if (result.status === "miss") {
+      await this.put(key, value);
+    }
     return value;
   }
 
   async getIfPresent<T>(key: GCacheKey): Promise<T | undefined> {
+    const result = await this.getIfPresentResult<T>(key);
+    return result.status === "hit" ? result.value : undefined;
+  }
+
+  async getIfPresentResult<T>(key: GCacheKey): Promise<CacheGetResult<T>> {
     const layerConfig = await this.resolveLocalLayerConfig(key);
-    if (layerConfig === null) {
-      return undefined;
+    if (layerConfig.status === "disabled") {
+      return layerConfig;
     }
 
     const cache = this.caches.get(key.useCase);
@@ -40,24 +48,24 @@ export class LocalCache {
     const hit = cache?.get(key.urn) as LocalEntry<T> | undefined;
 
     if (hit !== undefined && hit.expiresAtMs > now) {
-      return hit.value;
+      return { status: "hit", value: hit.value };
     }
 
     if (hit !== undefined) {
       cache?.delete(key.urn);
     }
 
-    return undefined;
+    return { status: "miss" };
   }
 
   async put<T>(key: GCacheKey, value: T): Promise<void> {
     const layerConfig = await this.resolveLocalLayerConfig(key);
-    if (layerConfig === null) {
+    if (layerConfig.status === "disabled") {
       return;
     }
 
     const cache = this.getOrCreateUseCaseCache(key);
-    cache.set(key.urn, { expiresAtMs: Date.now() + layerConfig.ttlSec * 1000, value });
+    cache.set(key.urn, { expiresAtMs: Date.now() + layerConfig.config.ttlSec * 1000, value });
     this.evictOldestIfNeeded(cache);
   }
 
@@ -80,7 +88,7 @@ export class LocalCache {
   }
 
   private async resolveLocalLayerConfig(key: GCacheKey) {
-    return await resolveLayerConfig({
+    return await resolveLayerConfigResult({
       configProvider: this.configProvider,
       key,
       layer: CacheLayer.LOCAL,

--- a/packages/gcache-ts/src/internal/redis-cache.ts
+++ b/packages/gcache-ts/src/internal/redis-cache.ts
@@ -1,7 +1,12 @@
+import { performance } from "node:perf_hooks";
+
 import { CacheLayer, type CacheConfigProvider, type CacheRampSampler } from "../config.js";
 import type { GCacheKey } from "../key.js";
+import type { GCacheMetricsAdapter } from "../metrics.js";
+import { labelsFor } from "../metrics.js";
 import { JsonSerializer, type Serializer } from "../serializer.js";
-import { resolveLayerConfig } from "./runtime-config.js";
+import type { CacheGetResult } from "./cache-result.js";
+import { resolveLayerConfigResult } from "./runtime-config.js";
 
 export type Awaitable<T> = T | Promise<T>;
 export type RedisStoredValue = string | Buffer;
@@ -37,6 +42,7 @@ interface RedisCacheOptions {
   readonly configProvider: CacheConfigProvider;
   readonly rampSampler: CacheRampSampler;
   readonly redis: RedisConfig;
+  readonly metrics: GCacheMetricsAdapter | null;
 }
 
 const ENVELOPE_VERSION = 1;
@@ -48,6 +54,7 @@ export class RedisCache {
   private readonly keyPrefix: string;
   private readonly defaultSerializer: Serializer<unknown>;
   private readonly createClient: RedisClientFactory | null;
+  private readonly metrics: GCacheMetricsAdapter | null;
   private clientPromise: Promise<RedisCommandClient> | null;
 
   constructor(options: RedisCacheOptions) {
@@ -55,6 +62,7 @@ export class RedisCache {
     this.rampSampler = options.rampSampler;
     this.keyPrefix = options.redis.keyPrefix ?? "";
     this.defaultSerializer = options.redis.serializer ?? defaultSerializer;
+    this.metrics = options.metrics;
 
     if (options.redis.client === undefined && options.redis.createClient === undefined) {
       throw new Error("Redis config requires either client or createClient");
@@ -65,44 +73,62 @@ export class RedisCache {
   }
 
   async get<T>(key: GCacheKey): Promise<T | undefined> {
+    const result = await this.getResult<T>(key);
+    return result.status === "hit" ? result.value : undefined;
+  }
+
+  async getResult<T>(key: GCacheKey): Promise<CacheGetResult<T>> {
     const layerConfig = await this.resolveRemoteLayerConfig(key);
-    if (layerConfig === null) {
-      return undefined;
+    if (layerConfig.status === "disabled") {
+      return layerConfig;
     }
 
     const client = await this.resolveClient();
     const raw = await client.get(this.redisKey(key));
     if (raw === null) {
-      return undefined;
+      return { status: "miss" };
     }
 
     const envelope = this.parseEnvelope(raw);
     if (envelope.expiresAtMs <= Date.now()) {
       await client.del(this.redisKey(key));
-      return undefined;
+      return { status: "miss" };
     }
 
-    return (await this.serializerFor(key).load(this.decodePayload(envelope))) as T;
+    const start = performance.now();
+    try {
+      const value = (await this.serializerFor(key).load(this.decodePayload(envelope))) as T;
+      return { status: "hit", value };
+    } finally {
+      this.metrics?.observeSerialization({ ...labelsFor(key, CacheLayer.REMOTE), operation: "load" }, elapsedSeconds(start));
+    }
   }
 
   async put<T>(key: GCacheKey, value: T): Promise<void> {
     const layerConfig = await this.resolveRemoteLayerConfig(key);
-    if (layerConfig === null) {
+    if (layerConfig.status === "disabled") {
       return;
     }
 
     const client = await this.resolveClient();
     const now = Date.now();
-    const payload = await this.serializerFor(key).dump(value);
+    const start = performance.now();
+    let payload: string | Buffer;
+    try {
+      payload = await this.serializerFor(key).dump(value);
+    } finally {
+      this.metrics?.observeSerialization({ ...labelsFor(key, CacheLayer.REMOTE), operation: "dump" }, elapsedSeconds(start));
+    }
+    this.metrics?.observeSize(labelsFor(key, CacheLayer.REMOTE), payloadSize(payload));
     const envelope: RedisValueEnvelope = {
       version: ENVELOPE_VERSION,
       createdAtMs: now,
-      expiresAtMs: now + layerConfig.ttlSec * 1000,
+      expiresAtMs: now + layerConfig.config.ttlSec * 1000,
       encoding: Buffer.isBuffer(payload) ? "base64" : "utf8",
       payload: Buffer.isBuffer(payload) ? payload.toString("base64") : payload,
     };
 
-    await this.setWithTtl(client, this.redisKey(key), JSON.stringify(envelope), layerConfig.ttlSec);
+    await this.setWithTtl(client, this.redisKey(key), JSON.stringify(envelope), layerConfig.config.ttlSec);
   }
 
   async delete(key: GCacheKey): Promise<boolean> {
@@ -177,11 +203,19 @@ export class RedisCache {
   }
 
   private async resolveRemoteLayerConfig(key: GCacheKey) {
-    return await resolveLayerConfig({
+    return await resolveLayerConfigResult({
       configProvider: this.configProvider,
       key,
       layer: CacheLayer.REMOTE,
       rampSampler: this.rampSampler,
     });
   }
+}
+
+function payloadSize(payload: string | Buffer): number {
+  return Buffer.isBuffer(payload) ? payload.byteLength : Buffer.byteLength(payload);
+}
+
+function elapsedSeconds(startMs: number): number {
+  return Math.max((performance.now() - startMs) / 1000, 0);
 }

--- a/packages/gcache-ts/src/internal/runtime-config.ts
+++ b/packages/gcache-ts/src/internal/runtime-config.ts
@@ -1,10 +1,15 @@
 import { CacheLayer, type CacheConfigProvider, type CacheRampSampler } from "../config.js";
 import type { GCacheKey } from "../key.js";
+import type { DisabledReason } from "../metrics.js";
 
 export interface ResolvedLayerConfig {
   readonly ttlSec: number;
   readonly ramp: number;
 }
+
+export type LayerConfigResolution =
+  | { readonly status: "enabled"; readonly config: ResolvedLayerConfig }
+  | { readonly status: "disabled"; readonly reason: DisabledReason };
 
 interface ResolveLayerConfigOptions {
   readonly configProvider: CacheConfigProvider;
@@ -14,30 +19,45 @@ interface ResolveLayerConfigOptions {
 }
 
 export async function resolveLayerConfig(options: ResolveLayerConfigOptions): Promise<ResolvedLayerConfig | null> {
+  const resolution = await resolveLayerConfigResult(options);
+  return resolution.status === "enabled" ? resolution.config : null;
+}
+
+export async function resolveLayerConfigResult(options: ResolveLayerConfigOptions): Promise<LayerConfigResolution> {
   const config = (await options.configProvider(options.key)) ?? options.key.defaultConfig;
   if (config === null) {
-    return null;
+    return { status: "disabled", reason: "missing_config" };
   }
 
   const ttlSec = config.ttlSec[options.layer];
-  if (ttlSec === undefined || ttlSec <= 0) {
-    return null;
+  if (ttlSec === undefined) {
+    return { status: "disabled", reason: "missing_config" };
+  }
+  if (ttlSec <= 0) {
+    return { status: "disabled", reason: "invalid_ttl" };
   }
 
-  const ramp = clampPercentage(config.ramp[options.layer] ?? 0);
+  const configuredRamp = config.ramp[options.layer];
+  if (configuredRamp === undefined) {
+    return { status: "disabled", reason: "missing_config" };
+  }
+
+  const ramp = clampPercentage(configuredRamp);
   if (ramp <= 0) {
-    return null;
+    return { status: "disabled", reason: "ramped_down" };
   }
   if (ramp >= 100) {
-    return { ttlSec, ramp };
+    return { status: "enabled", config: { ttlSec, ramp } };
   }
 
   const sample = await options.rampSampler({ key: options.key, layer: options.layer, ramp });
   if (!Number.isFinite(sample)) {
-    return null;
+    return { status: "disabled", reason: "ramped_down" };
   }
 
-  return clampPercentage(sample) < ramp ? { ttlSec, ramp } : null;
+  return clampPercentage(sample) < ramp
+    ? { status: "enabled", config: { ttlSec, ramp } }
+    : { status: "disabled", reason: "ramped_down" };
 }
 
 function clampPercentage(value: number): number {

--- a/packages/gcache-ts/src/metrics.ts
+++ b/packages/gcache-ts/src/metrics.ts
@@ -1,0 +1,205 @@
+import { Counter, Histogram, type Registry, register as defaultRegistry } from "prom-client";
+
+import { CacheLayer } from "./config.js";
+import type { GCacheKey } from "./key.js";
+
+export type MetricLayer = CacheLayer | "noop";
+export type DisabledReason = "context" | "missing_config" | "invalid_ttl" | "ramped_down" | "config_error";
+
+export interface CacheMetricLabels {
+  readonly useCase: string;
+  readonly keyType: string;
+  readonly layer: MetricLayer;
+}
+
+export interface DisabledMetricLabels extends CacheMetricLabels {
+  readonly reason: DisabledReason;
+}
+
+export interface ErrorMetricLabels extends CacheMetricLabels {
+  readonly error: string;
+  readonly inFallback: boolean;
+}
+
+export interface SerializationMetricLabels extends CacheMetricLabels {
+  readonly operation: "dump" | "load";
+}
+
+export interface InvalidationMetricLabels {
+  readonly keyType: string;
+  readonly layer: CacheLayer;
+}
+
+export interface GCacheMetricsAdapter {
+  request(labels: CacheMetricLabels): void;
+  miss(labels: CacheMetricLabels): void;
+  disabled(labels: DisabledMetricLabels): void;
+  error(labels: ErrorMetricLabels): void;
+  invalidation(labels: InvalidationMetricLabels): void;
+  observeGet(labels: CacheMetricLabels, seconds: number): void;
+  observeFallback(labels: CacheMetricLabels, seconds: number): void;
+  observeSerialization(labels: SerializationMetricLabels, seconds: number): void;
+  observeSize(labels: CacheMetricLabels, bytes: number): void;
+}
+
+export interface PrometheusMetricsOptions {
+  readonly prefix?: string;
+  readonly registry?: Registry;
+}
+
+type CounterLabels = "use_case" | "key_type" | "layer";
+type DisabledLabels = CounterLabels | "reason";
+type ErrorLabels = CounterLabels | "error" | "in_fallback";
+type SerializationLabels = CounterLabels | "operation";
+type InvalidationLabels = "key_type" | "layer";
+
+const TIMER_BUCKETS = [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10];
+const SIZE_BUCKETS = [100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000];
+
+export class PrometheusGCacheMetrics implements GCacheMetricsAdapter {
+  private readonly requestCounter: Counter<CounterLabels>;
+  private readonly missCounter: Counter<CounterLabels>;
+  private readonly disabledCounter: Counter<DisabledLabels>;
+  private readonly errorCounter: Counter<ErrorLabels>;
+  private readonly invalidationCounter: Counter<InvalidationLabels>;
+  private readonly getTimer: Histogram<CounterLabels>;
+  private readonly fallbackTimer: Histogram<CounterLabels>;
+  private readonly serializationTimer: Histogram<SerializationLabels>;
+  private readonly sizeHistogram: Histogram<CounterLabels>;
+
+  constructor(options: PrometheusMetricsOptions = {}) {
+    const registry = options.registry ?? defaultRegistry;
+    const prefix = options.prefix ?? "";
+
+    this.disabledCounter = counter(registry, {
+      name: `${prefix}gcache_disabled_counter`,
+      help: "Requests where GCache skipped a cache layer.",
+      labelNames: ["use_case", "key_type", "layer", "reason"] as const,
+    });
+    this.missCounter = counter(registry, {
+      name: `${prefix}gcache_miss_counter`,
+      help: "GCache cache misses.",
+      labelNames: ["use_case", "key_type", "layer"] as const,
+    });
+    this.requestCounter = counter(registry, {
+      name: `${prefix}gcache_request_counter`,
+      help: "Total GCache cache-layer requests.",
+      labelNames: ["use_case", "key_type", "layer"] as const,
+    });
+    this.errorCounter = counter(registry, {
+      name: `${prefix}gcache_error_counter`,
+      help: "Errors during GCache cache operations or fallback execution.",
+      labelNames: ["use_case", "key_type", "layer", "error", "in_fallback"] as const,
+    });
+    this.invalidationCounter = counter(registry, {
+      name: `${prefix}gcache_invalidation_counter`,
+      help: "GCache invalidation/delete calls by key type and layer.",
+      labelNames: ["key_type", "layer"] as const,
+    });
+    this.getTimer = histogram(registry, {
+      name: `${prefix}gcache_get_timer`,
+      help: "GCache cache get latency in seconds.",
+      labelNames: ["use_case", "key_type", "layer"] as const,
+      buckets: TIMER_BUCKETS,
+    });
+    this.fallbackTimer = histogram(registry, {
+      name: `${prefix}gcache_fallback_timer`,
+      help: "Time spent in the underlying fallback function in seconds.",
+      labelNames: ["use_case", "key_type", "layer"] as const,
+      buckets: TIMER_BUCKETS,
+    });
+    this.serializationTimer = histogram(registry, {
+      name: `${prefix}gcache_serialization_timer`,
+      help: "GCache serialization latency in seconds.",
+      labelNames: ["use_case", "key_type", "layer", "operation"] as const,
+      buckets: TIMER_BUCKETS,
+    });
+    this.sizeHistogram = histogram(registry, {
+      name: `${prefix}gcache_size_histogram`,
+      help: "Serialized GCache value sizes in bytes.",
+      labelNames: ["use_case", "key_type", "layer"] as const,
+      buckets: SIZE_BUCKETS,
+    });
+  }
+
+  request(labels: CacheMetricLabels): void {
+    this.requestCounter.inc(cacheLabels(labels));
+  }
+
+  miss(labels: CacheMetricLabels): void {
+    this.missCounter.inc(cacheLabels(labels));
+  }
+
+  disabled(labels: DisabledMetricLabels): void {
+    this.disabledCounter.inc({ ...cacheLabels(labels), reason: labels.reason });
+  }
+
+  error(labels: ErrorMetricLabels): void {
+    this.errorCounter.inc({
+      ...cacheLabels(labels),
+      error: labels.error,
+      in_fallback: String(labels.inFallback),
+    });
+  }
+
+  invalidation(labels: InvalidationMetricLabels): void {
+    this.invalidationCounter.inc({ key_type: labels.keyType, layer: labels.layer });
+  }
+
+  observeGet(labels: CacheMetricLabels, seconds: number): void {
+    this.getTimer.observe(cacheLabels(labels), seconds);
+  }
+
+  observeFallback(labels: CacheMetricLabels, seconds: number): void {
+    this.fallbackTimer.observe(cacheLabels(labels), seconds);
+  }
+
+  observeSerialization(labels: SerializationMetricLabels, seconds: number): void {
+    this.serializationTimer.observe({ ...cacheLabels(labels), operation: labels.operation }, seconds);
+  }
+
+  observeSize(labels: CacheMetricLabels, bytes: number): void {
+    this.sizeHistogram.observe(cacheLabels(labels), bytes);
+  }
+}
+
+export function createPrometheusGCacheMetrics(options: PrometheusMetricsOptions = {}): GCacheMetricsAdapter {
+  return new PrometheusGCacheMetrics(options);
+}
+
+export function labelsFor(key: GCacheKey, layer: MetricLayer): CacheMetricLabels {
+  return { useCase: key.useCase, keyType: key.keyType, layer };
+}
+
+export function errorName(error: unknown): string {
+  return error instanceof Error ? error.name : typeof error;
+}
+
+function cacheLabels(labels: CacheMetricLabels): Record<CounterLabels, string> {
+  return {
+    use_case: labels.useCase,
+    key_type: labels.keyType,
+    layer: labels.layer,
+  };
+}
+
+function counter<T extends string>(
+  registry: Registry,
+  config: { readonly name: string; readonly help: string; readonly labelNames: readonly T[] },
+): Counter<T> {
+  return (registry.getSingleMetric(config.name) as Counter<T> | undefined) ??
+    new Counter<T>({ ...config, registers: [registry] });
+}
+
+function histogram<T extends string>(
+  registry: Registry,
+  config: {
+    readonly name: string;
+    readonly help: string;
+    readonly labelNames: readonly T[];
+    readonly buckets: readonly number[];
+  },
+): Histogram<T> {
+  return (registry.getSingleMetric(config.name) as Histogram<T> | undefined) ??
+    new Histogram<T>({ ...config, buckets: [...config.buckets], registers: [registry] });
+}

--- a/packages/gcache-ts/test/gcache-metrics.test.ts
+++ b/packages/gcache-ts/test/gcache-metrics.test.ts
@@ -1,0 +1,299 @@
+import { Registry } from "prom-client";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CacheLayer,
+  GCache,
+  GCacheKeyConfig,
+  type CacheMetricLabels,
+  type DisabledMetricLabels,
+  type ErrorMetricLabels,
+  type GCacheMetricsAdapter,
+  type InvalidationMetricLabels,
+  type RedisCommandClient,
+  type RedisStoredValue,
+  type SerializationMetricLabels,
+} from "../src/index.js";
+
+class FakeRedis implements RedisCommandClient {
+  readonly values = new Map<string, RedisStoredValue>();
+  failGet = false;
+
+  async get(key: string): Promise<RedisStoredValue | null> {
+    if (this.failGet) {
+      throw new Error("redis unavailable");
+    }
+    return this.values.get(key) ?? null;
+  }
+
+  async setEx(key: string, _ttlSec: number, value: RedisStoredValue): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async del(key: string): Promise<number> {
+    return this.values.delete(key) ? 1 : 0;
+  }
+}
+
+class RecordingMetrics implements GCacheMetricsAdapter {
+  readonly events: Array<{ readonly name: string; readonly labels: Record<string, unknown>; readonly value?: number }> = [];
+
+  request(labels: CacheMetricLabels): void {
+    this.record("request", labels);
+  }
+
+  miss(labels: CacheMetricLabels): void {
+    this.record("miss", labels);
+  }
+
+  disabled(labels: DisabledMetricLabels): void {
+    this.record("disabled", labels);
+  }
+
+  error(labels: ErrorMetricLabels): void {
+    this.record("error", labels);
+  }
+
+  invalidation(labels: InvalidationMetricLabels): void {
+    this.record("invalidation", labels);
+  }
+
+  observeGet(labels: CacheMetricLabels, seconds: number): void {
+    this.record("get", labels, seconds);
+  }
+
+  observeFallback(labels: CacheMetricLabels, seconds: number): void {
+    this.record("fallback", labels, seconds);
+  }
+
+  observeSerialization(labels: SerializationMetricLabels, seconds: number): void {
+    this.record("serialization", labels, seconds);
+  }
+
+  observeSize(labels: CacheMetricLabels, bytes: number): void {
+    this.record("size", labels, bytes);
+  }
+
+  private record(name: string, labels: object, value?: number): void {
+    this.events.push({ name, labels: { ...labels }, ...(value === undefined ? {} : { value }) });
+  }
+}
+
+const localOnly = (ttlSec = 60) =>
+  new GCacheKeyConfig({
+    ttlSec: { [CacheLayer.LOCAL]: ttlSec },
+    ramp: { [CacheLayer.LOCAL]: 100 },
+  });
+
+const remoteOnly = () =>
+  new GCacheKeyConfig({
+    ttlSec: { [CacheLayer.REMOTE]: 60 },
+    ramp: { [CacheLayer.REMOTE]: 100 },
+  });
+
+describe("GCache observability metrics", () => {
+  it("reuses existing Prometheus collectors when multiple caches share a registry", async () => {
+    // Given two GCache instances use the same custom Prometheus registry and metric names.
+    const registry = new Registry();
+    const firstCache = new GCache({ metricsRegistry: registry });
+    const secondCache = new GCache({ metricsRegistry: registry });
+    const first = firstCache.cached({
+      keyType: "user_id",
+      useCase: "DuplicateMetricRegistrationFirst",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: localOnly(),
+    })(async (userId: string) => ({ userId }));
+    const second = secondCache.cached({
+      keyType: "user_id",
+      useCase: "DuplicateMetricRegistrationSecond",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: localOnly(),
+    })(async (userId: string) => ({ userId }));
+
+    // When both caches emit request metrics.
+    await firstCache.enable(async () => await first("123"));
+    await secondCache.enable(async () => await second("456"));
+
+    // Then construction does not throw duplicate-registration errors and both samples land in one collector.
+    await expect(sumMetric(registry, "gcache_request_counter")).resolves.toBe(2);
+    await expect(registry.getSingleMetricAsString("gcache_request_counter")).resolves.toContain(
+      "gcache_request_counter",
+    );
+  });
+
+  it("supports an injected metrics adapter without requiring Prometheus", async () => {
+    // Given a custom in-memory metrics adapter.
+    const metrics = new RecordingMetrics();
+    const gcache = new GCache({ metrics });
+    let calls = 0;
+    const getUser = gcache.cached({
+      keyType: "user_id",
+      useCase: "CustomMetricsAdapter",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: localOnly(),
+    })(async (userId: string) => ({ userId, calls: ++calls }));
+
+    // When a local miss is followed by a local hit.
+    const first = await gcache.enable(async () => await getUser("123"));
+    const second = await gcache.enable(async () => await getUser("123"));
+
+    // Then the adapter receives behavioral request/miss/timer events for the local layer.
+    expect(first).toEqual({ userId: "123", calls: 1 });
+    expect(second).toEqual({ userId: "123", calls: 1 });
+    expect(events(metrics, "request", { useCase: "CustomMetricsAdapter", layer: CacheLayer.LOCAL })).toHaveLength(2);
+    expect(events(metrics, "miss", { useCase: "CustomMetricsAdapter", layer: CacheLayer.LOCAL })).toHaveLength(1);
+    expect(events(metrics, "fallback", { useCase: "CustomMetricsAdapter", layer: CacheLayer.LOCAL })).toHaveLength(1);
+    expect(events(metrics, "get", { useCase: "CustomMetricsAdapter", layer: CacheLayer.LOCAL })).toHaveLength(2);
+  });
+
+  it("classifies disabled cache skips by reason", async () => {
+    // Given one cache call is outside context and other enabled calls have disabled layer config.
+    const metrics = new RecordingMetrics();
+    const gcache = new GCache({ metrics });
+    const contextDisabled = gcache.cached({
+      keyType: "user_id",
+      useCase: "DisabledByContext",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: localOnly(),
+    })(async (userId: string) => userId);
+    const missingConfig = gcache.cached({
+      keyType: "user_id",
+      useCase: "DisabledByMissingConfig",
+      id: ([userId]: [string]) => userId,
+    })(async (userId: string) => userId);
+    const invalidTtl = gcache.cached({
+      keyType: "user_id",
+      useCase: "DisabledByInvalidTtl",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: localOnly(0),
+    })(async (userId: string) => userId);
+    const rampedDown = gcache.cached({
+      keyType: "user_id",
+      useCase: "DisabledByRamp",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: new GCacheKeyConfig({
+        ttlSec: { [CacheLayer.LOCAL]: 60 },
+        ramp: { [CacheLayer.LOCAL]: 0 },
+      }),
+    })(async (userId: string) => userId);
+
+    // When each path is called.
+    await contextDisabled("123");
+    await gcache.enable(async () => {
+      await missingConfig("123");
+      await invalidTtl("123");
+      await rampedDown("123");
+    });
+
+    // Then disabled metrics preserve the operational reason labels.
+    expect(events(metrics, "disabled", { useCase: "DisabledByContext", layer: "noop", reason: "context" })).toHaveLength(1);
+    expect(
+      events(metrics, "disabled", { useCase: "DisabledByMissingConfig", layer: CacheLayer.LOCAL, reason: "missing_config" }),
+    ).toHaveLength(1);
+    expect(events(metrics, "disabled", { useCase: "DisabledByInvalidTtl", layer: CacheLayer.LOCAL, reason: "invalid_ttl" })).toHaveLength(1);
+    expect(events(metrics, "disabled", { useCase: "DisabledByRamp", layer: CacheLayer.LOCAL, reason: "ramped_down" })).toHaveLength(1);
+  });
+
+  it("labels cache errors separately from fallback errors", async () => {
+    // Given one Redis-backed cache has a cache read failure and another has a fallback failure.
+    const metrics = new RecordingMetrics();
+    const logger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const failingRedis = new FakeRedis();
+    failingRedis.failGet = true;
+    const cacheFailure = new GCache({ redis: { client: failingRedis }, metrics, logger });
+    const readThroughFailure = cacheFailure.cached({
+      keyType: "user_id",
+      useCase: "CacheErrorClassification",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: remoteOnly(),
+    })(async (userId: string) => ({ userId }));
+    const fallbackCache = new GCache({ redis: { client: new FakeRedis() }, metrics, logger });
+    const fallbackFailure = fallbackCache.cached({
+      keyType: "user_id",
+      useCase: "FallbackErrorClassification",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: remoteOnly(),
+    })(async () => {
+      throw new TypeError("database failed");
+    });
+
+    // When the cache error fails open and the fallback error escapes.
+    await cacheFailure.enable(async () => await readThroughFailure("123"));
+    await expect(fallbackCache.enable(async () => await fallbackFailure("123"))).rejects.toThrow("database failed");
+
+    // Then error labels identify whether the failure came from cache plumbing or from the fallback.
+    expect(
+      events(metrics, "error", {
+        useCase: "CacheErrorClassification",
+        layer: CacheLayer.REMOTE,
+        error: "Error",
+        inFallback: false,
+      }),
+    ).toHaveLength(1);
+    expect(
+      events(metrics, "error", {
+        useCase: "FallbackErrorClassification",
+        layer: CacheLayer.REMOTE,
+        error: "TypeError",
+        inFallback: true,
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("exports Prometheus counters and histograms for requests, misses, fallbacks, gets, serialization, and size", async () => {
+    // Given a custom Prometheus registry and a Redis-backed cached function.
+    const registry = new Registry();
+    const redis = new FakeRedis();
+    const gcache = new GCache({ redis: { client: redis }, metricsRegistry: registry, metricsPrefix: "test_" });
+    let calls = 0;
+    const getUser = gcache.cached({
+      keyType: "user_id",
+      useCase: "PrometheusMetricExport",
+      id: ([userId]: [string]) => userId,
+      defaultConfig: remoteOnly(),
+    })(async (userId: string) => ({ userId, calls: ++calls }));
+
+    // When the first read misses Redis and the second read hits Redis.
+    const first = await gcache.enable(async () => await getUser("123"));
+    const second = await gcache.enable(async () => await getUser("123"));
+
+    // Then Prometheus contains Python-aligned metric families with the expected label values.
+    expect(first).toEqual({ userId: "123", calls: 1 });
+    expect(second).toEqual({ userId: "123", calls: 1 });
+    await expect(sumMetric(registry, "test_gcache_request_counter", { use_case: "PrometheusMetricExport", layer: "remote" })).resolves.toBe(2);
+    await expect(sumMetric(registry, "test_gcache_miss_counter", { use_case: "PrometheusMetricExport", layer: "remote" })).resolves.toBe(1);
+    await expect(sumMetric(registry, "test_gcache_get_timer", { use_case: "PrometheusMetricExport", layer: "remote" })).resolves.toBeGreaterThan(0);
+    await expect(sumMetric(registry, "test_gcache_fallback_timer", { use_case: "PrometheusMetricExport", layer: "remote" })).resolves.toBeGreaterThan(0);
+    await expect(
+      sumMetric(registry, "test_gcache_serialization_timer", { use_case: "PrometheusMetricExport", layer: "remote" }),
+    ).resolves.toBeGreaterThan(0);
+    await expect(sumMetric(registry, "test_gcache_size_histogram", { use_case: "PrometheusMetricExport", layer: "remote" })).resolves.toBeGreaterThan(0);
+  });
+});
+
+function events(
+  metrics: RecordingMetrics,
+  name: string,
+  labels: Record<string, string | boolean>,
+): Array<{ readonly name: string; readonly labels: Record<string, unknown>; readonly value?: number }> {
+  return metrics.events.filter(
+    (event) => event.name === name && Object.entries(labels).every(([key, value]) => event.labels[key] === value),
+  );
+}
+
+async function sumMetric(
+  registry: Registry,
+  name: string,
+  labels: Record<string, string> = {},
+): Promise<number> {
+  const metrics = (await registry.getMetricsAsJSON()) as Array<{
+    readonly name: string;
+    readonly values: Array<{ readonly value: number; readonly labels: Record<string, string | number> }>;
+  }>;
+  const metric = metrics.find((candidate) => candidate.name === name);
+  return (
+    metric?.values
+      .filter((sample) => Object.entries(labels).every(([key, value]) => sample.labels[key] === value))
+      .reduce((total, sample) => total + sample.value, 0) ?? 0
+  );
+}

--- a/packages/gcache-ts/test/gcache-observability-internals.test.ts
+++ b/packages/gcache-ts/test/gcache-observability-internals.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CacheLayer, GCacheKey, GCacheKeyConfig, type RedisCommandClient, type RedisStoredValue } from "../src/index.js";
+import { LocalCache } from "../src/internal/local-cache.js";
+import { RedisCache, type RedisValueEnvelope } from "../src/internal/redis-cache.js";
+import { resolveLayerConfig } from "../src/internal/runtime-config.js";
+import { errorName } from "../src/metrics.js";
+
+class MemoryRedis implements RedisCommandClient {
+  readonly values = new Map<string, RedisStoredValue>();
+
+  async get(key: string): Promise<RedisStoredValue | null> {
+    return this.values.get(key) ?? null;
+  }
+
+  async setEx(key: string, _ttlSec: number, value: RedisStoredValue): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async del(key: string): Promise<number> {
+    return this.values.delete(key) ? 1 : 0;
+  }
+}
+
+const key = (defaultConfig: GCacheKeyConfig | null = GCacheKeyConfig.enabled(60)) =>
+  new GCacheKey({ keyType: "user_id", id: "123", useCase: "ObservabilityInternals", defaultConfig });
+
+describe("GCache observability internal compatibility paths", () => {
+  it("keeps LocalCache get/getIfPresent compatibility while exposing disabled reads", async () => {
+    // Given a local cache with enabled config and a second key with no config.
+    const cache = new LocalCache(async () => null, () => 0, 10);
+    const enabledKey = key();
+    const disabledKey = key(null);
+    let calls = 0;
+
+    // When get() populates a value and getIfPresent() reads it back.
+    const first = await cache.get(enabledKey, async () => ({ calls: ++calls }));
+    const hit = await cache.getIfPresent<{ calls: number }>(enabledKey);
+    const disabled = await cache.getIfPresentResult(disabledKey);
+
+    // Then compatibility helpers still behave like the pre-metrics API, and disabled state is explicit.
+    expect(first).toEqual({ calls: 1 });
+    expect(hit).toEqual({ calls: 1 });
+    expect(disabled).toEqual({ status: "disabled", reason: "missing_config" });
+    expect(calls).toBe(1);
+  });
+
+  it("keeps RedisCache get compatibility and skips writes when remote config is disabled", async () => {
+    // Given a Redis cache with one valid stored envelope and one key without remote config.
+    const redis = new MemoryRedis();
+    const redisCache = new RedisCache({
+      configProvider: async () => null,
+      rampSampler: () => 0,
+      redis: { client: redis },
+      metrics: null,
+    });
+    const enabledKey = key();
+    const disabledKey = new GCacheKey({
+      keyType: "user_id",
+      id: "456",
+      useCase: "ObservabilityInternals",
+      defaultConfig: new GCacheKeyConfig({
+        ttlSec: { [CacheLayer.LOCAL]: 60 },
+        ramp: { [CacheLayer.LOCAL]: 100 },
+      }),
+    });
+    redis.values.set(
+      enabledKey.urn,
+      JSON.stringify({
+        version: 1,
+        createdAtMs: Date.now(),
+        expiresAtMs: Date.now() + 60_000,
+        encoding: "utf8",
+        payload: JSON.stringify({ source: "redis" }),
+      } satisfies RedisValueEnvelope),
+    );
+
+    // When the compatibility get() reads Redis and put() sees disabled remote config.
+    const hit = await redisCache.get<{ source: string }>(enabledKey);
+    await redisCache.put(disabledKey, { source: "fallback" });
+
+    // Then get() unwraps the value and the disabled remote write is skipped.
+    expect(hit).toEqual({ source: "redis" });
+    expect(redis.values.has(disabledKey.urn)).toBe(false);
+  });
+
+  it("preserves runtime-config and error-name edge behavior used by metrics", async () => {
+    // Given configs for missing ramp and non-finite ramp samples.
+    const missingRamp = new GCacheKeyConfig({ ttlSec: { [CacheLayer.LOCAL]: 60 }, ramp: {} });
+    const partialRamp = new GCacheKeyConfig({
+      ttlSec: { [CacheLayer.LOCAL]: 60 },
+      ramp: { [CacheLayer.LOCAL]: 50 },
+    });
+
+    // When runtime config is resolved through compatibility and sampled disabled paths.
+    const noConfig = await resolveLayerConfig({
+      configProvider: async () => null,
+      key: key(null),
+      layer: CacheLayer.LOCAL,
+      rampSampler: vi.fn(),
+    });
+    const noRamp = await resolveLayerConfig({
+      configProvider: async () => missingRamp,
+      key: key(),
+      layer: CacheLayer.LOCAL,
+      rampSampler: vi.fn(),
+    });
+    const nonFiniteSample = await resolveLayerConfig({
+      configProvider: async () => partialRamp,
+      key: key(),
+      layer: CacheLayer.LOCAL,
+      rampSampler: () => Number.NaN,
+    });
+
+    // Then disabled config returns null and non-Error throws get stable metric labels.
+    expect(noConfig).toBeNull();
+    expect(noRamp).toBeNull();
+    expect(nonFiniteSample).toBeNull();
+    expect(errorName("string failure")).toBe("string");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,10 @@ importers:
   .: {}
 
   packages/gcache-ts:
+    dependencies:
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
     devDependencies:
       '@types/node':
         specifier: ^24.10.1
@@ -24,7 +28,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.14
-        version: 4.1.6(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7))
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7))
 
 packages:
 
@@ -232,6 +236,10 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@oxc-project/types@0.129.0':
     resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
@@ -546,6 +554,9 @@ packages:
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -804,6 +815,10 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -852,6 +867,9 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -1139,6 +1157,8 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@oxc-project/types@0.129.0': {}
 
   '@rolldown/binding-android-arm64@1.0.0':
@@ -1301,7 +1321,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7))
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7))
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -1355,6 +1375,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  bintrees@1.0.2: {}
 
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
@@ -1570,6 +1592,11 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   readdirp@4.1.2: {}
 
   resolve-from@5.0.0: {}
@@ -1652,6 +1679,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -1726,7 +1757,7 @@ snapshots:
       esbuild: 0.27.7
       fsevents: 2.3.3
 
-  vitest@4.1.6(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)):
+  vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7)):
     dependencies:
       '@vitest/expect': 4.1.6
       '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@24.12.4)(esbuild@0.27.7))
@@ -1749,6 +1780,7 @@ snapshots:
       vite: 8.0.12(@types/node@24.12.4)(esbuild@0.27.7)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 24.12.4
       '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- add observability hooks for requests, misses, disabled cache paths, cache/fallback errors, invalidation calls, get/fallback/serialization timers, and serialized value sizes
- add Prometheus support via `prom-client` with custom registry/prefix support and duplicate collector reuse
- support custom metrics adapters for non-Prometheus integrations
- improve cache-vs-fallback error classification and disabled-reason labels
- document Milestone 4 metrics behavior and add Given/When/Then behavioral coverage

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm ts:gcache:typecheck`
- `pnpm ts:gcache:test` — 42 tests, coverage: 97.3% statements / 93.4% branches / 97.8% functions / 97.55% lines
- `pnpm ts:gcache:build`

## Stack
Stacked on #135 / `lev/ts-m3-config-ramp`. This PR intentionally leaves targeted invalidation/watermarks and framework integrations for later milestone PRs.
