### PR TITLE
fix(ts): use lru-cache for local layer, deterministic key sort, safety docs

### DIFF
--- a/packages/gcache-ts/README.md
+++ b/packages/gcache-ts/README.md
@@ -63,6 +63,9 @@ local cache -> Redis cache -> fallback function
 - Redis cache read/write failures are logged, counted in metrics, and fail open; fallback results still return when fallback succeeds. Explicit maintenance calls (`delete`, `invalidate`, `flushAll`) log/count Redis failures and rethrow them so callers do not assume mutation succeeded.
 - Missing per-layer config disables that layer, records a disabled reason, and falls through to the next layer/fallback.
 
+> [!WARNING]
+> `gcache.flushAll()` issues Redis `FLUSHALL`, which deletes **every key in the entire Redis instance**, not just keys under `keyPrefix`. Do not call it against a Redis instance shared with other data — use `gcache.delete(key)` or `gcache.invalidate(keyType, id)` for targeted removal.
+
 You can also provide `createClient` for lazy client construction:
 
 ```ts
@@ -118,7 +121,8 @@ A cached Redis value whose `createdAtMs` is older than or equal to the watermark
 
 Watermarks use `DEFAULT_WATERMARK_TTL_SEC` (4 hours) by default. You can override it with `redis.watermarkTtlSec`, but it must exceed the maximum Redis cache TTL for invalidation-tracked data; otherwise a watermark can expire before old cached values do.
 
-Local cache limitation: targeted invalidation is enforced by Redis watermarks. Existing local cache hits are not synchronously invalidated across processes, so strongly invalidated mutable data should disable the local layer (or use very short local TTLs only when stale reads are acceptable).
+> [!IMPORTANT]
+> **The local layer is not supported for sensitive/strong invalidation.** Targeted invalidation is enforced *only* by Redis watermarks — `trackForInvalidation` consults the watermark on the Redis layer alone. Local cache hits are not synchronously invalidated across processes, and a value can still be written to local cache while the remote layer is disabled or ramped down. Any data that must be correct after `invalidate()` should disable the local layer entirely (omit `CacheLayer.LOCAL` from `ttlSec`/`ramp`). Use a local TTL only when stale reads are acceptable.
 
 ## Runtime config and ramp controls
 

--- a/packages/gcache-ts/package.json
+++ b/packages/gcache-ts/package.json
@@ -35,6 +35,7 @@
     "node": ">=18.17"
   },
   "dependencies": {
+    "lru-cache": "^10.4.3",
     "prom-client": "^15.1.3"
   }
 }

--- a/packages/gcache-ts/src/gcache.ts
+++ b/packages/gcache-ts/src/gcache.ts
@@ -163,6 +163,14 @@ export class GCache {
     }
   }
 
+  /**
+   * Clears every configured cache layer.
+   *
+   * WARNING: the Redis layer issues `FLUSHALL`, which deletes **all** keys in the
+   * entire Redis instance — not just keys under the GCache `keyPrefix`. Never call
+   * this against a Redis instance shared with other data; use {@link delete} or
+   * {@link invalidate} for targeted removal instead.
+   */
   async flushAll(): Promise<void> {
     await this.localCache.flushAll();
     if (this.redisCache === null) {

--- a/packages/gcache-ts/src/internal/local-cache.ts
+++ b/packages/gcache-ts/src/internal/local-cache.ts
@@ -1,3 +1,5 @@
+import { LRUCache } from "lru-cache";
+
 import { CacheLayer, type CacheConfigProvider, type CacheRampSampler } from "../config.js";
 import type { GCacheKey } from "../key.js";
 import type { CacheGetResult } from "./cache-result.js";
@@ -5,19 +7,29 @@ import { resolveLayerConfigResult } from "./runtime-config.js";
 
 export type Fallback<T> = () => Promise<T>;
 
-interface LocalEntry<T> {
-  readonly expiresAtMs: number;
+// Each entry carries its own expiry. TTL is enforced with `Date.now()` (consistent
+// with the Redis layer and mockable in tests) rather than lru-cache's internal
+// `performance.now()` clock; lru-cache handles only LRU + max-size eviction. The
+// wrapper is always defined, so an `undefined` fallback result stays cacheable
+// (`LRUCache.set(key, undefined)` is an alias for `delete`).
+interface CachedEntry<T> {
   readonly value: T;
+  readonly expiresAtMs: number;
 }
 
 export class LocalCache {
-  private readonly caches = new Map<string, Map<string, LocalEntry<unknown>>>();
+  // A single LRU keyed by the fully-qualified URN (which already encodes the use
+  // case). One global instance bounds total local memory and gives true LRU
+  // eviction across all use cases.
+  private readonly cache: LRUCache<string, CachedEntry<unknown>>;
 
   constructor(
     private readonly configProvider: CacheConfigProvider,
     private readonly rampSampler: CacheRampSampler,
-    private readonly maxSize: number,
-  ) {}
+    maxSize: number,
+  ) {
+    this.cache = new LRUCache<string, CachedEntry<unknown>>({ max: maxSize });
+  }
 
   async get<T>(key: GCacheKey, fallback: Fallback<T>): Promise<T> {
     const result = await this.getIfPresentResult<T>(key);
@@ -43,48 +55,33 @@ export class LocalCache {
       return layerConfig;
     }
 
-    const cache = this.caches.get(key.useCase);
-    const now = Date.now();
-    const hit = cache?.get(key.urn) as LocalEntry<T> | undefined;
-
-    if (hit !== undefined && hit.expiresAtMs > now) {
+    const hit = this.cache.get(key.urn) as CachedEntry<T> | undefined;
+    if (hit !== undefined && hit.expiresAtMs > Date.now()) {
       return { status: "hit", value: hit.value };
     }
 
     if (hit !== undefined) {
-      cache?.delete(key.urn);
+      this.cache.delete(key.urn);
     }
 
     return { status: "miss", config: layerConfig.config };
   }
 
   async put<T>(key: GCacheKey, value: T, config?: { readonly ttlSec: number }): Promise<void> {
-    const ttlSec = config?.ttlSec ?? await this.resolveLocalTtlSec(key);
+    const ttlSec = config?.ttlSec ?? (await this.resolveLocalTtlSec(key));
     if (ttlSec === null) {
       return;
     }
 
-    const cache = this.getOrCreateUseCaseCache(key);
-    cache.set(key.urn, { expiresAtMs: Date.now() + ttlSec * 1000, value });
-    this.evictOldestIfNeeded(cache);
+    this.cache.set(key.urn, { value, expiresAtMs: Date.now() + ttlSec * 1000 });
   }
 
   async delete(key: GCacheKey): Promise<boolean> {
-    const cache = this.caches.get(key.useCase);
-    return cache?.delete(key.urn) ?? false;
+    return this.cache.delete(key.urn);
   }
 
   async flushAll(): Promise<void> {
-    this.caches.clear();
-  }
-
-  private getOrCreateUseCaseCache(key: GCacheKey): Map<string, LocalEntry<unknown>> {
-    let cache = this.caches.get(key.useCase);
-    if (cache === undefined) {
-      cache = new Map<string, LocalEntry<unknown>>();
-      this.caches.set(key.useCase, cache);
-    }
-    return cache;
+    this.cache.clear();
   }
 
   private async resolveLocalLayerConfig(key: GCacheKey) {
@@ -99,15 +96,5 @@ export class LocalCache {
   private async resolveLocalTtlSec(key: GCacheKey): Promise<number | null> {
     const layerConfig = await this.resolveLocalLayerConfig(key);
     return layerConfig.status === "enabled" ? layerConfig.config.ttlSec : null;
-  }
-
-  private evictOldestIfNeeded(cache: Map<string, LocalEntry<unknown>>): void {
-    while (cache.size > this.maxSize) {
-      const oldestKey = cache.keys().next().value as string | undefined;
-      if (oldestKey === undefined) {
-        return;
-      }
-      cache.delete(oldestKey);
-    }
   }
 }

--- a/packages/gcache-ts/src/key.ts
+++ b/packages/gcache-ts/src/key.ts
@@ -49,7 +49,9 @@ export function normalizeArgs(args: Record<string, string | number | boolean | b
   return Object.entries(args)
     .filter(([, value]) => value !== undefined)
     .map(([name, value]) => [name, String(value)] as [string, string])
-    .sort(([left], [right]) => left.localeCompare(right));
+    // Sort by UTF-16 code unit, not localeCompare: the cache key must be byte-for-byte
+    // identical across processes, and localeCompare is locale/ICU-version dependent.
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
 }
 
 export function invalidationPrefix(urnPrefix: string, keyType: string, id: string): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   packages/gcache-ts:
     dependencies:
+      lru-cache:
+        specifier: ^10.4.3
+        version: 10.4.3
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -744,6 +747,9 @@ packages:
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1530,6 +1536,8 @@ snapshots:
   lines-and-columns@1.2.4: {}
 
   load-tsconfig@0.2.5: {}
+
+  lru-cache@10.4.3: {}
 
   magic-string@0.30.21:
     dependencies:


### PR DESCRIPTION
## Summary

Follow-up hardening from the review of #137 (TypeScript GCache package). No public API changes; the behavior changes all move toward correctness/safety.

## Changes

- **Local cache now uses [`lru-cache`](https://github.com/isaacs/node-lru-cache)** instead of a hand-rolled `Map`. The previous implementation evicted FIFO (insertion order) and bounded size *per use case* (worst-case memory `maxSize × number_of_use_cases`). It is now true **LRU** eviction with a single global instance keyed by URN, so `localMaxSize` is a real global bound.
  - TTL remains enforced via `Date.now()` (consistent with the Redis layer and mockable under fake timers); `lru-cache` handles only LRU + max-size. lru-cache's own TTL clock uses `performance.now()`, which the test suite's fake timers don't mock.
  - Values are boxed (`{ value, expiresAtMs }`) so an `undefined` fallback result stays cacheable (`lru-cache.set(k, undefined)` is an alias for `delete`).
- **Deterministic cache keys:** `normalizeArgs` sorts argument names by UTF-16 code unit instead of `localeCompare` (which is locale/ICU-version dependent). Prevents the same logical call from producing different URNs on different hosts, which would silently lower the Redis hit rate.
- **Docs/safety:**
  - `flushAll()` JSDoc + README `WARNING`: it issues Redis `FLUSHALL`, which wipes the **entire Redis instance**, not just `keyPrefix` keys.
  - README `IMPORTANT`: the local layer is **not supported for sensitive/strong invalidation** (`trackForInvalidation` only consults the Redis watermark; local hits are not synchronously invalidated, and a value can be written to local while the remote layer is ramped down).

## Dependency

Adds `lru-cache@^10`. Pinned to v10 (not v11) to preserve the package's declared `engines.node: ">=18.17"` — `lru-cache@11` requires Node `20 || >=22`. If you'd rather adopt v11 and drop EOL Node 18, that's a one-line bump to both `lru-cache` and `engines.node`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm ts:gcache:typecheck` — clean
- `pnpm ts:gcache:test` — 73 passed, coverage 97.7% statements / 92.12% branches / 97.65% functions / 97.84% lines
- `pnpm ts:gcache:build` — esm + cjs + dts

## Deferred (non-blocking)

Review items intentionally left for later: `prom-client` loads even with `metrics: false`; CI `on: push` + `pull_request` double-runs; redundant `workspaces` field in root `package.json`; `get` timer includes config-provider latency; no direct test asserting LRU eviction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)