### PR TITLE
fix: instrument fallback after cache read errors

### DIFF
--- a/src/gcache/_internal/wrappers.py
+++ b/src/gcache/_internal/wrappers.py
@@ -104,7 +104,20 @@ class CacheController(CacheWrapper):
                         raise
                     if fallback_succeeded:
                         return fallback_result
-                    return await instrumented_fallback()
+                    try:
+                        return await instrumented_fallback()
+                    except Exception as fallback_error:
+                        _GLOBAL_GCACHE_STATE.logger.error(
+                            f"Error getting value from cache: {fallback_error}", exc_info=True
+                        )
+                        GCacheMetrics.ERROR_COUNTER.labels(
+                            key.use_case,
+                            key.key_type,
+                            self.layer().name,
+                            type(fallback_error).__name__,
+                            True,
+                        ).inc()
+                        raise
             finally:
                 GCacheMetrics.GET_TIMER.labels(key.use_case, key.key_type, self.layer().name).observe(
                     time.monotonic() - start_time - fallback_time

--- a/src/gcache/_internal/wrappers.py
+++ b/src/gcache/_internal/wrappers.py
@@ -104,7 +104,7 @@ class CacheController(CacheWrapper):
                         raise
                     if fallback_succeeded:
                         return fallback_result
-                    return await fallback()
+                    return await instrumented_fallback()
             finally:
                 GCacheMetrics.GET_TIMER.labels(key.use_case, key.key_type, self.layer().name).observe(
                     time.monotonic() - start_time - fallback_time

--- a/src/gcache/_internal/wrappers.py
+++ b/src/gcache/_internal/wrappers.py
@@ -108,7 +108,7 @@ class CacheController(CacheWrapper):
                         return await instrumented_fallback()
                     except Exception as fallback_error:
                         _GLOBAL_GCACHE_STATE.logger.error(
-                            f"Error getting value from cache: {fallback_error}", exc_info=True
+                            f"Error in fallback after cache read failure: {fallback_error}", exc_info=True
                         )
                         GCacheMetrics.ERROR_COUNTER.labels(
                             key.use_case,

--- a/src/gcache/_internal/wrappers.py
+++ b/src/gcache/_internal/wrappers.py
@@ -66,14 +66,20 @@ class CacheController(CacheWrapper):
                 GCacheMetrics.REQUEST_COUNTER.labels(key.use_case, key.key_type, self.layer().name).inc()
 
                 fallback_failed = False
+                fallback_succeeded = False
+                fallback_result: Any = None
 
                 async def instrumented_fallback() -> Any:
                     nonlocal fallback_failed
+                    nonlocal fallback_result
+                    nonlocal fallback_succeeded
                     nonlocal fallback_time
                     start_fallback = time.monotonic()
                     GCacheMetrics.MISS_COUNTER.labels(key.use_case, key.key_type, self.layer().name).inc()
                     try:
-                        return await fallback()
+                        fallback_result = await fallback()
+                        fallback_succeeded = True
+                        return fallback_result
                     except Exception:
                         fallback_failed = True
                         raise
@@ -94,10 +100,11 @@ class CacheController(CacheWrapper):
                         type(e).__name__,
                         fallback_failed,
                     ).inc()
-                    if not fallback_failed:
-                        return await fallback()
-                    else:
+                    if fallback_failed:
                         raise
+                    if fallback_succeeded:
+                        return fallback_result
+                    return await fallback()
             finally:
                 GCacheMetrics.GET_TIMER.labels(key.use_case, key.key_type, self.layer().name).observe(
                     time.monotonic() - start_time - fallback_time

--- a/tests/test_cache_controller.py
+++ b/tests/test_cache_controller.py
@@ -1,0 +1,160 @@
+import logging
+from typing import Any, cast
+
+import pytest
+from redis.asyncio import Redis
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+from gcache import GCacheKey, GCacheKeyConfig
+from gcache._internal.cache_interface import Fallback
+from gcache._internal.metrics import GCacheMetrics
+from gcache._internal.redis_cache import RedisCache
+from gcache._internal.state import GCacheContext
+from gcache._internal.wrappers import CacheController
+from gcache.config import _default_config_provider
+
+
+class StubRedisClient:
+    def __init__(
+        self,
+        *,
+        read_error: Exception | None = None,
+        write_error: Exception | None = None,
+    ) -> None:
+        self.read_error = read_error
+        self.write_error = write_error
+        self.get_calls = 0
+        self.setex_calls = 0
+
+    async def get(self, key: str) -> bytes | None:
+        self.get_calls += 1
+        if self.read_error is not None:
+            raise self.read_error
+        return None
+
+    async def setex(self, key: str, ttl: int, value: bytes) -> None:
+        self.setex_calls += 1
+        if self.write_error is not None:
+            raise self.write_error
+
+
+def _controller(client: StubRedisClient) -> CacheController:
+    redis_cache = RedisCache(_default_config_provider, lambda: cast(Redis, client))
+    return CacheController(redis_cache, _default_config_provider, metrics_prefix="api_")
+
+
+def _key(use_case: str) -> GCacheKey:
+    return GCacheKey(
+        key_type="Test",
+        id="123",
+        use_case=use_case,
+        default_config=GCacheKeyConfig.enabled(60),
+    )
+
+
+async def _enabled_get(controller: CacheController, key: GCacheKey, fallback: Fallback) -> Any:
+    token = GCacheContext.enabled.set(True)
+    try:
+        return await controller.get(key, fallback)
+    finally:
+        GCacheContext.enabled.reset(token)
+
+
+def _error_metric(controller: CacheController, key: GCacheKey, error: type[Exception], in_fallback: bool) -> Any:
+    return GCacheMetrics.ERROR_COUNTER.labels(
+        key.use_case,
+        key.key_type,
+        controller.layer().name,
+        error.__name__,
+        in_fallback,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fallback_value",
+    [
+        pytest.param(None, id="none"),
+        pytest.param(False, id="false"),
+        pytest.param(0, id="zero"),
+        pytest.param("", id="empty-string"),
+        pytest.param("source-value", id="truthy"),
+    ],
+)
+async def test_redis_put_failure_returns_successful_fallback_once(
+    fallback_value: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    error = RedisConnectionError("redis write failed")
+    client = StubRedisClient(write_error=error)
+    controller = _controller(client)
+    key = _key(f"redis_put_failure_{type(fallback_value).__name__}")
+    fallback_calls = 0
+    error_metric = _error_metric(controller, key, RedisConnectionError, False)
+    errors_before = error_metric._value.get()
+
+    async def fallback() -> Any:
+        nonlocal fallback_calls
+        fallback_calls += 1
+        return fallback_value
+
+    with caplog.at_level(logging.ERROR):
+        result = await _enabled_get(controller, key, fallback)
+
+    assert result == fallback_value
+    assert type(result) is type(fallback_value)
+    assert fallback_calls == 1
+    assert client.get_calls == 1
+    assert client.setex_calls == 1
+    assert error_metric._value.get() == errors_before + 1
+    assert "Error getting value from cache: redis write failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_redis_read_failure_calls_fallback_once(caplog: pytest.LogCaptureFixture) -> None:
+    error = RedisConnectionError("redis read failed")
+    client = StubRedisClient(read_error=error)
+    controller = _controller(client)
+    key = _key("redis_read_failure")
+    fallback_calls = 0
+    error_metric = _error_metric(controller, key, RedisConnectionError, False)
+    errors_before = error_metric._value.get()
+
+    async def fallback() -> str:
+        nonlocal fallback_calls
+        fallback_calls += 1
+        return "source-value"
+
+    with caplog.at_level(logging.ERROR):
+        result = await _enabled_get(controller, key, fallback)
+
+    assert result == "source-value"
+    assert fallback_calls == 1
+    assert client.get_calls == 1
+    assert client.setex_calls == 0
+    assert error_metric._value.get() == errors_before + 1
+    assert "Error getting value from cache: redis read failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_fallback_failure_is_propagated(caplog: pytest.LogCaptureFixture) -> None:
+    client = StubRedisClient()
+    controller = _controller(client)
+    key = _key("fallback_failure")
+    fallback_calls = 0
+    error_metric = _error_metric(controller, key, LookupError, True)
+    errors_before = error_metric._value.get()
+
+    async def fallback() -> None:
+        nonlocal fallback_calls
+        fallback_calls += 1
+        raise LookupError("source unavailable")
+
+    with caplog.at_level(logging.ERROR), pytest.raises(LookupError, match="source unavailable"):
+        await _enabled_get(controller, key, fallback)
+
+    assert fallback_calls == 1
+    assert client.get_calls == 1
+    assert client.setex_calls == 0
+    assert error_metric._value.get() == errors_before + 1
+    assert "Error getting value from cache: source unavailable" in caplog.text

--- a/tests/test_cache_controller.py
+++ b/tests/test_cache_controller.py
@@ -133,6 +133,7 @@ async def test_redis_read_failure_instruments_fallback_once(
         "key_type": key.key_type,
         "layer": controller.layer().name,
     }
+    requests_before = _metric_value("api_gcache_request_counter_total", metric_labels)
     misses_before = _metric_value("api_gcache_miss_counter_total", metric_labels)
     fallback_time_before = _metric_value("api_gcache_fallback_timer_sum", metric_labels)
     get_time_before = _metric_value("api_gcache_get_timer_sum", metric_labels)
@@ -155,10 +156,42 @@ async def test_redis_read_failure_instruments_fallback_once(
     assert client.get_calls == 1
     assert client.setex_calls == 0
     assert error_metric._value.get() == errors_before + 1
+    assert _metric_value("api_gcache_request_counter_total", metric_labels) == requests_before + 1
     assert _metric_value("api_gcache_miss_counter_total", metric_labels) == misses_before + 1
     assert _metric_value("api_gcache_fallback_timer_sum", metric_labels) == fallback_time_before + 10
     assert _metric_value("api_gcache_get_timer_sum", metric_labels) == get_time_before + 3
     assert "Error getting value from cache: redis read failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_redis_read_failure_records_subsequent_fallback_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    read_error = RedisConnectionError("redis read failed")
+    client = StubRedisClient(read_error=read_error)
+    controller = _controller(client)
+    key = _key("redis_read_and_fallback_failure")
+    fallback_calls = 0
+    read_error_metric = _error_metric(controller, key, RedisConnectionError, False)
+    fallback_error_metric = _error_metric(controller, key, LookupError, True)
+    read_errors_before = read_error_metric._value.get()
+    fallback_errors_before = fallback_error_metric._value.get()
+
+    async def fallback() -> None:
+        nonlocal fallback_calls
+        fallback_calls += 1
+        raise LookupError("source unavailable")
+
+    with caplog.at_level(logging.ERROR), pytest.raises(LookupError, match="source unavailable"):
+        await _enabled_get(controller, key, fallback)
+
+    assert fallback_calls == 1
+    assert client.get_calls == 1
+    assert client.setex_calls == 0
+    assert read_error_metric._value.get() == read_errors_before + 1
+    assert fallback_error_metric._value.get() == fallback_errors_before + 1
+    assert "Error getting value from cache: redis read failed" in caplog.text
+    assert "Error getting value from cache: source unavailable" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_cache_controller.py
+++ b/tests/test_cache_controller.py
@@ -191,7 +191,7 @@ async def test_redis_read_failure_records_subsequent_fallback_failure(
     assert read_error_metric._value.get() == read_errors_before + 1
     assert fallback_error_metric._value.get() == fallback_errors_before + 1
     assert "Error getting value from cache: redis read failed" in caplog.text
-    assert "Error getting value from cache: source unavailable" in caplog.text
+    assert "Error in fallback after cache read failure: source unavailable" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_cache_controller.py
+++ b/tests/test_cache_controller.py
@@ -1,7 +1,9 @@
 import logging
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
+from prometheus_client import REGISTRY
 from redis.asyncio import Redis
 from redis.exceptions import ConnectionError as RedisConnectionError
 
@@ -70,6 +72,10 @@ def _error_metric(controller: CacheController, key: GCacheKey, error: type[Excep
     )
 
 
+def _metric_value(name: str, labels: dict[str, str]) -> float:
+    return REGISTRY.get_sample_value(name, labels) or 0.0
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "fallback_value",
@@ -111,7 +117,10 @@ async def test_redis_put_failure_returns_successful_fallback_once(
 
 
 @pytest.mark.asyncio
-async def test_redis_read_failure_calls_fallback_once(caplog: pytest.LogCaptureFixture) -> None:
+async def test_redis_read_failure_instruments_fallback_once(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     error = RedisConnectionError("redis read failed")
     client = StubRedisClient(read_error=error)
     controller = _controller(client)
@@ -119,6 +128,19 @@ async def test_redis_read_failure_calls_fallback_once(caplog: pytest.LogCaptureF
     fallback_calls = 0
     error_metric = _error_metric(controller, key, RedisConnectionError, False)
     errors_before = error_metric._value.get()
+    metric_labels = {
+        "use_case": key.use_case,
+        "key_type": key.key_type,
+        "layer": controller.layer().name,
+    }
+    misses_before = _metric_value("api_gcache_miss_counter_total", metric_labels)
+    fallback_time_before = _metric_value("api_gcache_fallback_timer_sum", metric_labels)
+    get_time_before = _metric_value("api_gcache_get_timer_sum", metric_labels)
+    monotonic_values = iter((0.0, 1.0, 11.0, 13.0))
+    monkeypatch.setattr(
+        "gcache._internal.wrappers.time",
+        SimpleNamespace(monotonic=lambda: next(monotonic_values)),
+    )
 
     async def fallback() -> str:
         nonlocal fallback_calls
@@ -133,6 +155,9 @@ async def test_redis_read_failure_calls_fallback_once(caplog: pytest.LogCaptureF
     assert client.get_calls == 1
     assert client.setex_calls == 0
     assert error_metric._value.get() == errors_before + 1
+    assert _metric_value("api_gcache_miss_counter_total", metric_labels) == misses_before + 1
+    assert _metric_value("api_gcache_fallback_timer_sum", metric_labels) == fallback_time_before + 10
+    assert _metric_value("api_gcache_get_timer_sum", metric_labels) == get_time_before + 3
     assert "Error getting value from cache: redis read failed" in caplog.text
 
 


### PR DESCRIPTION
## Summary

Instrument the source fallback when a cache read fails, just as we already do for a normal cache miss.

This keeps cache observability accurate during Redis read outages without changing the fail-open result returned to callers. If the source also fails, the cache error and source error are both recorded with the correct `in_fallback` classification.

## Behavior

```text
Before
cache read fails -> raw fallback -> request + cache-error metrics only
                                -> source latency included in cache get time
                                -> source failure not recorded for this layer

After
cache read fails -> record cache error -> instrumented fallback
                                      -> request + miss metrics
                                      -> source latency recorded separately
                                      -> source failure recorded as in_fallback=true
```

The fallback still runs exactly once and fallback exceptions still propagate.

## Metrics impact

- `gcache_request_counter` continues to include the failed cache-read attempt.
- `gcache_miss_counter` now includes read failures that require the source fallback.
- `gcache_fallback_timer` now observes the source call after a read failure.
- `gcache_get_timer` continues to represent cache overhead without source latency.
- `gcache_error_counter` records both the cache read error and any subsequent source failure, with distinct `in_fallback` labels.

This corrects hit-rate dashboards derived as `1 - miss / request`, which previously treated cache read errors as hits.

## Validation

- Focused cache-controller tests: 8 passed
- Full suite: 73 passed, 2 skipped
- Ruff lint and formatting passed
- Mypy passed for source and tests
- Pre-commit passed
- `git diff --check` passed

## Relationship to #141

#141 is merged. This PR is now based directly on `main` and contains only the follow-up read-error metrics change.

## CI

The branch was refreshed from `main` after #141 merged. Fresh Python, TypeScript, pre-commit, title-validation, and Codecov checks all pass.
