### PR TITLE
ci: upgrade Codecov action to v7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
       # upload would fail with an empty Codecov token.
       - name: Upload Test Coverage Reports
         if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: codecov/codecov-action@v5.5.2
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -23,7 +23,7 @@ jobs:
       # upload would fail with an empty Codecov token.
       - name: Upload TypeScript Coverage Reports
         if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: codecov/codecov-action@v5.5.2
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/gcache-ts/coverage/lcov.info


### PR DESCRIPTION
## Summary

Upgrade both Python and TypeScript coverage uploads from `codecov/codecov-action@v5.5.2` to `v7.0.0`.

## Why

The pinned v5.5.2 action fetches Codecov's uploader verification key from the deleted `codecovsecurity` Keybase account. Coverage uploads fail after otherwise-successful tests with:

```text
gpg: Can't check signature: No public key
Could not verify signature
```

Codecov v7 migrates the wrapper to the replacement `codecovsecops` account. This keeps uploader integrity verification enabled instead of using `skip_validation` or `use_pypi`, both of which bypass that check.

## Why v7 instead of v5.5.5

Codecov v5.5.5 contains only the narrow signing-key URL correction. v7 also passes token inputs through step environment variables instead of interpolating them directly into shell commands. Since the v7 workflows pass end to end, this PR keeps that additional hardening rather than choosing the older minimal patch.

## Validation

- Parsed both workflow files as YAML
- `git diff --check` passed
- Python tests and coverage upload passed
- TypeScript tests and coverage upload passed
- Codecov project and patch checks passed

## References

- [Codecov v5.5.5 release](https://github.com/codecov/codecov-action/releases/tag/v5.5.5)
- [Codecov v7.0.0 release](https://github.com/codecov/codecov-action/releases/tag/v7.0.0)
- [Codecov upload failure report](https://github.com/codecov/codecov-action/issues/1955)
- [Codecov signing-key migration issue](https://github.com/codecov/codecov-action/issues/1956)
